### PR TITLE
feat: add role-level model settings

### DIFF
--- a/app/settings/actions.ts
+++ b/app/settings/actions.ts
@@ -32,6 +32,12 @@ const updateProviderSchema = z.object({
   allowInsecureTls: z.boolean().default(false)
 });
 
+const roleConfigSchema = z.object({
+  role: z.string().min(1),
+  modelName: z.string().min(1),
+  temperature: z.coerce.number().min(0).max(1)
+});
+
 function now() {
   return new Date().toISOString();
 }
@@ -164,13 +170,38 @@ export async function updateModelProvider(formData: FormData) {
     .where(eq(modelProviders.id, parsed.data.providerId));
 
   await db
-    .update(modelConfigs)
-    .set({
-      modelName: parsed.data.defaultModelName,
-      temperature,
-      updatedAt
-    })
+    .delete(modelConfigs)
     .where(eq(modelConfigs.providerId, parsed.data.providerId));
+
+  const roleConfigs = aiRoles.map((role) => {
+    const modelName =
+      String(formData.get(`roleModelName.${role.value}`) ?? "").trim() ||
+      parsed.data.defaultModelName;
+    const roleConfig = roleConfigSchema.safeParse({
+      role: role.value,
+      modelName,
+      temperature:
+        formData.get(`roleTemperature.${role.value}`) ??
+        parsed.data.temperature
+    });
+
+    if (!roleConfig.success) {
+      statusRedirect("error", `${role.label} 的模型或温度配置无效。`);
+    }
+
+    return {
+      id: crypto.randomUUID(),
+      providerId: parsed.data.providerId,
+      role: role.value,
+      modelName,
+      temperature: normalizeTemperature(roleConfig.data.temperature),
+      enabled: true,
+      createdAt: updatedAt,
+      updatedAt
+    };
+  });
+
+  await db.insert(modelConfigs).values(roleConfigs);
 
   revalidatePath("/settings");
   statusRedirect("success", "模型提供商已更新，请重新测试连接。");

--- a/src/components/settings/provider-card.tsx
+++ b/src/components/settings/provider-card.tsx
@@ -24,6 +24,7 @@ type ProviderCardProps = {
     configs: Array<{
       role: string;
       modelName: string;
+      temperature: number;
     }>;
   };
 };
@@ -145,6 +146,9 @@ export function ProviderCard({ provider }: ProviderCardProps) {
               <div className="mt-1 text-xs text-muted-foreground">
                 {config?.modelName ?? provider.defaultModelName}
               </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                温度：{((config?.temperature ?? provider.defaultTemperature) / 100).toFixed(1)}
+              </div>
             </div>
           );
         })}
@@ -196,6 +200,37 @@ function ProviderEditForm({ provider }: ProviderCardProps) {
           </span>
         </span>
       </label>
+      <div className="mt-5">
+        <div className="text-sm font-semibold">角色模型配置</div>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          可以为不同 AI 角色设置不同模型或温度。留用默认模型时保持与提供商默认模型一致。
+        </p>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          {aiRoles.map((role) => {
+            const config = provider.configs.find((item) => item.role === role.value);
+
+            return (
+              <div key={role.value} className="rounded-lg border border-border bg-background p-3">
+                <div className="text-sm font-semibold">{role.label}</div>
+                <div className="mt-3 grid gap-3">
+                  <EditField
+                    label="模型名称"
+                    name={`roleModelName.${role.value}`}
+                    defaultValue={config?.modelName ?? provider.defaultModelName}
+                  />
+                  <EditField
+                    label="温度"
+                    name={`roleTemperature.${role.value}`}
+                    defaultValue={String((config?.temperature ?? provider.defaultTemperature) / 100)}
+                    type="number"
+                    step="0.1"
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
       <div className="mt-4">
         <PendingButton
           className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"


### PR DESCRIPTION
## 关联 Issue
Closes #1

## 改动摘要
- 支持为 AI 导师、反方委员、考官、研究助理分别配置模型名和温度
- 在模型提供商编辑表单中增加角色模型配置区域
- 在已保存提供商卡片中展示各角色模型与温度
- 保存配置后重置连接测试状态，提示重新测试

## 验证
- [x] npm run typecheck

## 风险
- 保存提供商配置时会重建该提供商下的角色配置记录
- 不影响已加密保存的 API Key，除非用户主动填写新的 API Key

## 回退方案
- Revert commit: 79049bb