### PR TITLE
feat: add AI mentor chat MVP

### DIFF
--- a/app/api/mentor/chat/route.ts
+++ b/app/api/mentor/chat/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { sendAiConversationMessage } from "@/lib/ai/conversations";
+import type { AiRole } from "@/lib/ai/types";
+
+const chatRequestSchema = z.object({
+  conversationId: z.string().optional().nullable(),
+  role: z.enum(["mentor", "opponent", "examiner", "research_assistant"]),
+  content: z.string().trim().min(1, "请输入要咨询的问题。").max(8000, "单次消息不能超过 8000 字。")
+});
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const parsed = chatRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message: parsed.error.issues[0]?.message ?? "请求格式不正确。"
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await sendAiConversationMessage({
+      conversationId: parsed.data.conversationId,
+      role: parsed.data.role as AiRole,
+      content: parsed.data.content
+    });
+
+    return NextResponse.json({
+      ok: true,
+      ...result
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message: error instanceof Error ? error.message : "AI 导师暂时无法回复。"
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/mentor/conversations/[conversationId]/route.ts
+++ b/app/api/mentor/conversations/[conversationId]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { getConversationMessages } from "@/lib/ai/conversations";
+
+type RouteContext = {
+  params: Promise<{
+    conversationId: string;
+  }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { conversationId } = await context.params;
+  const messages = await getConversationMessages(conversationId);
+
+  return NextResponse.json({
+    ok: true,
+    messages
+  });
+}

--- a/app/mentor/page.tsx
+++ b/app/mentor/page.tsx
@@ -1,11 +1,54 @@
-import { PlaceholderPage } from "@/components/ui/placeholder-page";
+import Link from "next/link";
+import { SectionHeader } from "@/components/ui/section-header";
+import { MentorChat } from "@/components/mentor/mentor-chat";
+import { getMentorWorkspace } from "@/lib/ai/conversations";
+import { getModelProvidersWithConfigs } from "@/lib/model-config/queries";
 
-export default function MentorPage() {
+export default async function MentorPage() {
+  const [workspace, providers] = await Promise.all([
+    getMentorWorkspace(),
+    getModelProvidersWithConfigs()
+  ]);
+  const hasProvider = providers.length > 0;
+
   return (
-    <PlaceholderPage
-      title="AI 导师"
-      description="下一阶段会接入用户自配的 OpenAI API 兼容模型，并支持导师、反方委员、考官和研究助理四种角色。"
-      items={["导师模式", "反方委员模式", "考官模式", "研究助理模式"]}
-    />
+    <main className="space-y-6">
+      <section className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <SectionHeader
+            title="AI 投研教练"
+            description="用耐心导师讲清概念，用反方委员挑战假设，用考官检验理解，用研究助理整理资料。"
+          />
+          <Link
+            href="/settings"
+            className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-sm font-semibold transition hover:bg-muted"
+          >
+            模型配置
+          </Link>
+        </div>
+      </section>
+
+      {!hasProvider ? (
+        <section className="rounded-lg border border-border bg-card p-6">
+          <h2 className="text-lg font-semibold">先连接你的模型</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            AI 对话不会内置模型。请先在设置页添加 OpenAI API 兼容提供商，测试成功后再回来使用导师、反方委员、考官和研究助理。
+          </p>
+          <Link
+            href="/settings"
+            className="mt-4 inline-flex rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
+          >
+            去配置模型
+          </Link>
+        </section>
+      ) : (
+        <MentorChat
+          initialConversations={workspace.conversations}
+          initialConversationId={workspace.activeConversationId}
+          initialRole={workspace.activeRole}
+          initialMessages={workspace.messages}
+        />
+      )}
+    </main>
   );
 }

--- a/src/components/mentor/mentor-chat.tsx
+++ b/src/components/mentor/mentor-chat.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Bot, MessageSquarePlus, Send, ShieldAlert, UserRound } from "lucide-react";
+import { aiRoles } from "@/lib/model-config/constants";
+import type {
+  ConversationMessage,
+  ConversationSummary
+} from "@/lib/ai/conversations";
+import type { AiRole } from "@/lib/ai/types";
+
+type MentorChatProps = {
+  initialConversations: ConversationSummary[];
+  initialConversationId: string | null;
+  initialRole: AiRole;
+  initialMessages: ConversationMessage[];
+};
+
+export function MentorChat({
+  initialConversations,
+  initialConversationId,
+  initialRole,
+  initialMessages
+}: MentorChatProps) {
+  const [conversations, setConversations] = useState(initialConversations);
+  const [activeConversationId, setActiveConversationId] = useState(initialConversationId);
+  const [activeRole, setActiveRole] = useState<AiRole>(initialRole);
+  const [messages, setMessages] = useState(initialMessages);
+  const [input, setInput] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const activeRoleMeta = useMemo(
+    () => aiRoles.find((role) => role.value === activeRole) ?? aiRoles[0],
+    [activeRole]
+  );
+
+  function startNewConversation(role: AiRole = activeRole) {
+    setActiveConversationId(null);
+    setActiveRole(role);
+    setMessages([]);
+    setErrorMessage("");
+  }
+
+  async function selectConversation(conversation: ConversationSummary) {
+    setActiveConversationId(conversation.id);
+    setActiveRole(conversation.role);
+    setErrorMessage("");
+
+    const response = await fetch(`/api/mentor/conversations/${conversation.id}`);
+    const data = (await response.json()) as {
+      messages?: ConversationMessage[];
+      message?: string;
+    };
+
+    if (!response.ok) {
+      setErrorMessage(data.message ?? "对话加载失败。");
+      return;
+    }
+
+    setMessages(data.messages ?? []);
+  }
+
+  async function sendMessage() {
+    const content = input.trim();
+
+    if (!content || isSending) {
+      return;
+    }
+
+    const optimisticMessage: ConversationMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content,
+      createdAt: new Date().toISOString()
+    };
+
+    setMessages((current) => [...current, optimisticMessage]);
+    setInput("");
+    setIsSending(true);
+    setErrorMessage("");
+
+    try {
+      const response = await fetch("/api/mentor/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          conversationId: activeConversationId,
+          role: activeRole,
+          content
+        })
+      });
+      const data = (await response.json()) as {
+        ok?: boolean;
+        message?: string;
+        conversationId?: string;
+        assistantMessage?: ConversationMessage;
+      };
+
+      if (!response.ok || !data.ok || !data.assistantMessage || !data.conversationId) {
+        throw new Error(data.message ?? "AI 导师暂时无法回复。");
+      }
+
+      setActiveConversationId(data.conversationId);
+      setMessages((current) => [...current, data.assistantMessage as ConversationMessage]);
+      setConversations((current) => upsertConversation(current, data.conversationId as string, content, activeRole));
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "AI 导师暂时无法回复。");
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[280px_1fr]">
+      <aside className="rounded-lg border border-border bg-card p-4">
+        <button
+          type="button"
+          onClick={() => startNewConversation()}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
+        >
+          <MessageSquarePlus className="h-4 w-4" aria-hidden />
+          新建对话
+        </button>
+
+        <div className="mt-5 space-y-2">
+          {conversations.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border bg-background p-4 text-sm leading-6 text-muted-foreground">
+              还没有对话。选择一个角色，先问一个价值投资问题。
+            </div>
+          ) : (
+            conversations.map((conversation) => (
+              <button
+                key={conversation.id}
+                type="button"
+                onClick={() => selectConversation(conversation)}
+                className={`block w-full rounded-md border px-3 py-2 text-left text-sm transition ${
+                  activeConversationId === conversation.id
+                    ? "border-primary bg-muted text-foreground"
+                    : "border-border bg-background text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <span className="block truncate font-semibold">{conversation.title}</span>
+                <span className="mt-1 block text-xs">
+                  {aiRoles.find((role) => role.value === conversation.role)?.label ?? "AI 导师"}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      </aside>
+
+      <section className="min-h-[640px] rounded-lg border border-border bg-card">
+        <div className="border-b border-border p-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <Bot className="h-5 w-5 text-primary" aria-hidden />
+                <h1 className="text-xl font-semibold">{activeRoleMeta.label}</h1>
+              </div>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                {activeRoleMeta.description}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
+              {aiRoles.map((role) => (
+                <button
+                  key={role.value}
+                  type="button"
+                  onClick={() => startNewConversation(role.value)}
+                  className={`rounded-md border px-3 py-2 text-sm font-semibold transition ${
+                    activeRole === role.value
+                      ? "border-primary bg-muted"
+                      : "border-border bg-background hover:bg-muted"
+                  }`}
+                >
+                  {role.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4 p-5">
+          <div className="rounded-lg border border-border bg-background p-4">
+            <div className="flex items-start gap-3">
+              <ShieldAlert className="mt-0.5 h-5 w-5 text-primary" aria-hidden />
+              <p className="text-sm leading-6 text-muted-foreground">
+                AI 只用于学习、研究、质询和复盘，不输出买入、卖出或持有建议；最终判断由你依据自己的原则完成。
+              </p>
+            </div>
+          </div>
+
+          <div className="min-h-[360px] space-y-4">
+            {messages.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-border bg-background p-8 text-center">
+                <p className="text-sm font-semibold">从一个具体问题开始</p>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  例如：安全边际为什么不是简单打折？或者请反方委员质疑我的估值假设。
+                </p>
+              </div>
+            ) : (
+              messages.map((message) => <ChatBubble key={message.id} message={message} />)
+            )}
+            {isSending ? (
+              <div className="rounded-lg border border-border bg-background p-4 text-sm text-muted-foreground">
+                {activeRoleMeta.label}正在思考...
+              </div>
+            ) : null}
+          </div>
+
+          {errorMessage ? (
+            <div className="rounded-lg border border-border bg-muted p-4 text-sm leading-6 text-muted-foreground">
+              {errorMessage}
+            </div>
+          ) : null}
+
+          <div className="rounded-lg border border-border bg-background p-3">
+            <textarea
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={(event) => {
+                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                  void sendMessage();
+                }
+              }}
+              rows={4}
+              placeholder="输入你的问题、投资理由、估值假设或粘贴一段资料..."
+              className="w-full resize-none bg-transparent text-sm leading-6 outline-none"
+            />
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <span className="text-xs text-muted-foreground">Cmd/Ctrl + Enter 发送</span>
+              <button
+                type="button"
+                onClick={sendMessage}
+                disabled={!input.trim() || isSending}
+                className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+              >
+                <Send className="h-4 w-4" aria-hidden />
+                {isSending ? "发送中..." : "发送"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ChatBubble({ message }: { message: ConversationMessage }) {
+  const isUser = message.role === "user";
+
+  return (
+    <div className={`flex gap-3 ${isUser ? "justify-end" : "justify-start"}`}>
+      {!isUser ? (
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground">
+          <Bot className="h-4 w-4" aria-hidden />
+        </span>
+      ) : null}
+      <div
+        className={`max-w-3xl whitespace-pre-wrap rounded-lg border px-4 py-3 text-sm leading-6 ${
+          isUser
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-border bg-background text-foreground"
+        }`}
+      >
+        {message.content}
+      </div>
+      {isUser ? (
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-background">
+          <UserRound className="h-4 w-4" aria-hidden />
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function upsertConversation(
+  conversations: ConversationSummary[],
+  conversationId: string,
+  content: string,
+  role: AiRole
+) {
+  const existing = conversations.find((conversation) => conversation.id === conversationId);
+  const title = content.length > 24 ? `${content.slice(0, 24)}...` : content;
+  const nextConversation: ConversationSummary = {
+    id: conversationId,
+    title: existing?.title ?? title,
+    role,
+    updatedAt: new Date().toISOString()
+  };
+
+  return [
+    nextConversation,
+    ...conversations.filter((conversation) => conversation.id !== conversationId)
+  ];
+}

--- a/src/db/migrations/0002_rare_raider.sql
+++ b/src/db/migrations/0002_rare_raider.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `ai_conversations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text NOT NULL,
+	`role` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`provider_id`) REFERENCES `model_providers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `ai_messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`model_name` text DEFAULT '' NOT NULL,
+	`temperature` integer DEFAULT 20 NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`conversation_id`) REFERENCES `ai_conversations`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/src/db/migrations/meta/0002_snapshot.json
+++ b/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,515 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6e22ef4f-df63-4fbf-9b46-be30b5ac340a",
+  "prevId": "48eab926-bf3b-4af6-a1c6-9299b51ba7d4",
+  "tables": {
+    "ai_conversations": {
+      "name": "ai_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_conversations_provider_id_model_providers_id_fk": {
+          "name": "ai_conversations_provider_id_model_providers_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_messages": {
+      "name": "ai_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_messages_conversation_id_ai_conversations_id_fk": {
+          "name": "ai_messages_conversation_id_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_code": {
+          "name": "stock_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_name": {
+          "name": "stock_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_nodes": {
+      "name": "knowledge_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_configs_provider_id_model_providers_id_fk": {
+          "name": "model_configs_provider_id_model_providers_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_providers": {
+      "name": "model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_openai_compatible": {
+          "name": "is_openai_compatible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_insecure_tls": {
+          "name": "allow_insecure_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_name": {
+          "name": "default_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_temperature": {
+          "name": "default_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "max_context_tokens": {
+          "name": "max_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8000
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_tested'"
+        },
+        "last_test_message": {
+          "name": "last_test_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777685517520,
       "tag": "0001_milky_tenebrous",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777699350416,
+      "tag": "0002_rare_raider",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -31,6 +31,29 @@ export const modelConfigs = sqliteTable("model_configs", {
   updatedAt: text("updated_at").notNull()
 });
 
+export const aiConversations = sqliteTable("ai_conversations", {
+  id: text("id").primaryKey(),
+  title: text("title").notNull(),
+  role: text("role").notNull(),
+  providerId: text("provider_id")
+    .notNull()
+    .references(() => modelProviders.id, { onDelete: "cascade" }),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const aiMessages = sqliteTable("ai_messages", {
+  id: text("id").primaryKey(),
+  conversationId: text("conversation_id")
+    .notNull()
+    .references(() => aiConversations.id, { onDelete: "cascade" }),
+  role: text("role").notNull(),
+  content: text("content").notNull(),
+  modelName: text("model_name").notNull().default(""),
+  temperature: integer("temperature").notNull().default(20),
+  createdAt: text("created_at").notNull()
+});
+
 export const knowledgeNodes = sqliteTable("knowledge_nodes", {
   id: text("id").primaryKey(),
   type: text("type").notNull(),

--- a/src/lib/ai/conversations.ts
+++ b/src/lib/ai/conversations.ts
@@ -1,0 +1,214 @@
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { aiConversations, aiMessages } from "@/db/schema";
+import { callOpenAICompatibleChat } from "@/lib/ai/openai-compatible";
+import type { AiRole, ChatMessage } from "@/lib/ai/types";
+import { hasDirectTradingAdvice, sanitizeDirectTradingAdvice } from "@/lib/ai/guardrails";
+import { getAiRoleSystemPrompt } from "@/lib/ai/prompts";
+import { decryptSecret } from "@/lib/encryption/crypto";
+import { getModelProviderForRole } from "@/lib/model-config/queries";
+
+const MAX_HISTORY_MESSAGES = 16;
+
+export type ConversationSummary = {
+  id: string;
+  title: string;
+  role: AiRole;
+  updatedAt: string;
+};
+
+export type ConversationMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
+};
+
+function now() {
+  return new Date().toISOString();
+}
+
+function toAiRole(role: string): AiRole {
+  if (role === "opponent" || role === "examiner" || role === "research_assistant") {
+    return role;
+  }
+
+  return "mentor";
+}
+
+function createTitle(content: string) {
+  const compact = content.replace(/\s+/g, " ").trim();
+  return compact.length > 24 ? `${compact.slice(0, 24)}...` : compact || "新的导师对话";
+}
+
+export async function getMentorWorkspace() {
+  const conversations = await db
+    .select()
+    .from(aiConversations)
+    .orderBy(desc(aiConversations.updatedAt));
+
+  const activeConversation = conversations[0];
+  const messages = activeConversation
+    ? await getConversationMessages(activeConversation.id)
+    : [];
+
+  return {
+    conversations: conversations.map((conversation) => ({
+      id: conversation.id,
+      title: conversation.title,
+      role: toAiRole(conversation.role),
+      updatedAt: conversation.updatedAt
+    })),
+    activeConversationId: activeConversation?.id ?? null,
+    activeRole: toAiRole(activeConversation?.role ?? "mentor"),
+    messages
+  };
+}
+
+export async function getConversationMessages(conversationId: string) {
+  const rows = await db
+    .select()
+    .from(aiMessages)
+    .where(eq(aiMessages.conversationId, conversationId))
+    .orderBy(aiMessages.createdAt);
+
+  return rows
+    .filter((message) => message.role === "user" || message.role === "assistant")
+    .map((message) => ({
+      id: message.id,
+      role: message.role as "user" | "assistant",
+      content: message.content,
+      createdAt: message.createdAt
+    }));
+}
+
+export async function sendAiConversationMessage({
+  conversationId,
+  role,
+  content
+}: {
+  conversationId?: string | null;
+  role: AiRole;
+  content: string;
+}) {
+  const modelConfig = await getModelProviderForRole(role);
+
+  if (!modelConfig) {
+    throw new Error("还没有可用的模型配置。请先到设置页新增并测试模型提供商。");
+  }
+
+  const sentAt = now();
+  const normalizedContent = content.trim();
+  let currentConversationId = conversationId ?? "";
+
+  if (currentConversationId) {
+    const [existingConversation] = await db
+      .select()
+      .from(aiConversations)
+      .where(eq(aiConversations.id, currentConversationId));
+
+    if (!existingConversation) {
+      currentConversationId = "";
+    }
+  }
+
+  if (!currentConversationId) {
+    currentConversationId = crypto.randomUUID();
+    await db.insert(aiConversations).values({
+      id: currentConversationId,
+      title: createTitle(normalizedContent),
+      role,
+      providerId: modelConfig.provider.id,
+      createdAt: sentAt,
+      updatedAt: sentAt
+    });
+  } else {
+    await db
+      .update(aiConversations)
+      .set({
+        role,
+        providerId: modelConfig.provider.id,
+        updatedAt: sentAt
+      })
+      .where(eq(aiConversations.id, currentConversationId));
+  }
+
+  const historyRows = await db
+    .select()
+    .from(aiMessages)
+    .where(eq(aiMessages.conversationId, currentConversationId))
+    .orderBy(desc(aiMessages.createdAt))
+    .limit(MAX_HISTORY_MESSAGES);
+
+  await db.insert(aiMessages).values({
+    id: crypto.randomUUID(),
+    conversationId: currentConversationId,
+    role: "user",
+    content: normalizedContent,
+    modelName: "",
+    temperature: 0,
+    createdAt: sentAt
+  });
+
+  const chatMessages: ChatMessage[] = [
+    {
+      role: "system",
+      content: getAiRoleSystemPrompt(role)
+    },
+    ...historyRows
+      .reverse()
+      .filter((message) => message.role === "user" || message.role === "assistant")
+      .map((message) => ({
+        role: message.role as "user" | "assistant",
+        content: message.content
+      })),
+    {
+      role: "user",
+      content: normalizedContent
+    }
+  ];
+
+  const rawAssistantContent = await callOpenAICompatibleChat({
+    config: {
+      apiBaseUrl: modelConfig.provider.apiBaseUrl,
+      apiKey: decryptSecret(modelConfig.provider.apiKeyEncrypted),
+      model: modelConfig.modelName,
+      temperature: modelConfig.temperature / 100,
+      allowInsecureTls: modelConfig.provider.allowInsecureTls
+    },
+    messages: chatMessages
+  });
+
+  const assistantContent = hasDirectTradingAdvice(rawAssistantContent)
+    ? sanitizeDirectTradingAdvice(rawAssistantContent)
+    : rawAssistantContent;
+  const answeredAt = now();
+  const assistantMessageId = crypto.randomUUID();
+
+  await db.insert(aiMessages).values({
+    id: assistantMessageId,
+    conversationId: currentConversationId,
+    role: "assistant",
+    content: assistantContent,
+    modelName: modelConfig.modelName,
+    temperature: modelConfig.temperature,
+    createdAt: answeredAt
+  });
+
+  await db
+    .update(aiConversations)
+    .set({
+      updatedAt: answeredAt
+    })
+    .where(eq(aiConversations.id, currentConversationId));
+
+  return {
+    conversationId: currentConversationId,
+    assistantMessage: {
+      id: assistantMessageId,
+      role: "assistant" as const,
+      content: assistantContent,
+      createdAt: answeredAt
+    }
+  };
+}

--- a/src/lib/ai/guardrails.ts
+++ b/src/lib/ai/guardrails.ts
@@ -1,13 +1,32 @@
 const blockedAdvicePatterns = [
   "应该买入",
   "应该卖出",
+  "建议买入",
+  "建议卖出",
+  "可以买入",
+  "可以卖出",
+  "继续持有",
   "必须买入",
   "必须卖出",
   "最佳买点",
   "保证收益",
-  "必涨"
+  "必涨",
+  "满仓",
+  "重仓",
+  "加杠杆"
 ];
 
 export function hasDirectTradingAdvice(content: string) {
   return blockedAdvicePatterns.some((pattern) => content.includes(pattern));
+}
+
+export function sanitizeDirectTradingAdvice(content: string) {
+  const sanitized = blockedAdvicePatterns.reduce(
+    (current, pattern) => current.replaceAll(pattern, "不直接作出买卖结论"),
+    content
+  );
+
+  return `${sanitized}
+
+边界提醒：上面的内容仅用于学习、研究和复盘，不构成买入、卖出或持有建议。请回到你的投资原则、估值假设、风险清单和待确认事实，最终判断由你自己完成。`;
 }

--- a/src/lib/ai/prompts/index.ts
+++ b/src/lib/ai/prompts/index.ts
@@ -1,0 +1,22 @@
+import type { AiRole } from "@/lib/ai/types";
+import { examinerPrompt } from "@/lib/ai/prompts/examiner";
+import { mentorPrompt } from "@/lib/ai/prompts/mentor";
+import { opponentPrompt } from "@/lib/ai/prompts/opponent";
+import { researchAssistantPrompt } from "@/lib/ai/prompts/research-assistant";
+
+const globalBoundaryPrompt = `共同边界：
+- 你服务于价值投资学习、训练、估值解释、研究整理和复盘，不替用户做最终投资决策。
+- 不输出直接买入、卖出、持有、满仓、重仓、加杠杆、保证收益、最佳买点等结论。
+- 涉及具体 A 股公司时，必须回到信息来源、估值假设、风险清单、用户原则和下一步待确认问题。
+- 可以解释方法、指出条件是否满足、提示风险和提出反方问题，但最终判断始终由用户完成。`;
+
+const rolePrompts: Record<AiRole, string> = {
+  mentor: mentorPrompt,
+  opponent: opponentPrompt,
+  examiner: examinerPrompt,
+  research_assistant: researchAssistantPrompt
+};
+
+export function getAiRoleSystemPrompt(role: AiRole) {
+  return `${rolePrompts[role]}\n\n${globalBoundaryPrompt}`;
+}

--- a/src/lib/model-config/queries.ts
+++ b/src/lib/model-config/queries.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { modelConfigs, modelProviders } from "@/db/schema";
+import type { AiRole } from "@/lib/ai/types";
 
 export async function getModelProvidersWithConfigs() {
   const [providers, configs] = await Promise.all([
@@ -18,4 +19,28 @@ export async function getModelProviderForTest(providerId: string) {
   const [provider] = await db.select().from(modelProviders).where(eq(modelProviders.id, providerId));
 
   return provider;
+}
+
+export async function getModelProviderForRole(role: AiRole) {
+  const [providers, configs] = await Promise.all([
+    db.select().from(modelProviders).where(eq(modelProviders.status, "active")),
+    db.select().from(modelConfigs)
+  ]);
+
+  if (providers.length === 0) {
+    return null;
+  }
+
+  const successProvider = providers.find((provider) => provider.lastTestStatus === "success");
+  const provider = successProvider ?? providers[0];
+  const providerConfigs = configs.filter((config) => config.providerId === provider.id);
+  const config =
+    providerConfigs.find((item) => item.role === role && item.enabled) ??
+    providerConfigs.find((item) => item.enabled);
+
+  return {
+    provider,
+    modelName: config?.modelName ?? provider.defaultModelName,
+    temperature: config?.temperature ?? provider.defaultTemperature
+  };
 }


### PR DESCRIPTION
## 关联 Issue
Closes #3

## 改动摘要
- 新增 AI 会话与消息表，支持本地保存导师对话
- 新增 OpenAI API 兼容聊天 API，按角色读取模型配置并服务端解密 API Key
- 新增四类角色系统提示词入口，统一投资建议边界
- 将 /mentor 从占位页升级为可选择角色、发送问题、查看历史对话的对话页面
- 增强直接买卖建议关键词拦截与边界提醒

## 主要文件
- app/mentor/page.tsx
- src/components/mentor/mentor-chat.tsx
- app/api/mentor/chat/route.ts
- src/lib/ai/conversations.ts
- src/db/schema.ts
- src/db/migrations/0002_rare_raider.sql

## 验证
- [x] npm run db:generate
- [x] npm run db:migrate
- [x] npm run typecheck
- [x] npm run build
- [x] HTTP 验证 /mentor 返回 200

## 截图 / 说明
- 本地 /mentor 页面已可展示 AI 投研教练界面、角色切换、新建对话和输入框
- in-app browser 后端本次未连接成功，已使用本地 HTTP 与构建验证替代

## 数据库迁移
- 新增 ai_conversations 表
- 新增 ai_messages 表
- 本地已执行迁移，不提交 data/local.db

## 风险
- 第一版不做流式输出，长回答需要等待完整响应
- 模型服务失败时会展示错误提示，用户消息会保存在当前会话中
- 当前只做基础关键词级输出边界拦截，后续需要更系统的 AI 输出审查

## 回退方案
- Revert commit: bb5da52