### PR TITLE
feat: add watchlist MVP

### DIFF
--- a/app/watchlist/actions.ts
+++ b/app/watchlist/actions.ts
@@ -1,0 +1,102 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { companies } from "@/db/schema";
+
+const companySchema = z.object({
+  stockCode: z.string().trim().min(1, "请填写股票代码"),
+  stockName: z.string().trim().min(1, "请填写公司名称"),
+  exchange: z.string().trim().min(1),
+  industry: z.string().trim().default(""),
+  companyType: z.string().trim().default("other"),
+  watchStatus: z.string().trim().default("watching"),
+  valuationStatus: z.string().trim().default("not_started"),
+  inCircle: z.boolean().default(false),
+  thesis: z.string().trim().default(""),
+  keyRisks: z.string().trim().default(""),
+  nextAction: z.string().trim().default(""),
+  description: z.string().trim().default("")
+});
+
+const updateSchema = companySchema.extend({
+  companyId: z.string().trim().min(1)
+});
+
+function now() {
+  return new Date().toISOString();
+}
+
+function normalizeCode(value: string) {
+  return value.replace(/\s+/g, "").toUpperCase();
+}
+
+export async function addCompany(formData: FormData) {
+  const parsed = companySchema.safeParse({
+    stockCode: formData.get("stockCode"),
+    stockName: formData.get("stockName"),
+    exchange: formData.get("exchange"),
+    industry: formData.get("industry"),
+    companyType: formData.get("companyType"),
+    watchStatus: formData.get("watchStatus"),
+    valuationStatus: formData.get("valuationStatus"),
+    inCircle: formData.get("inCircle") === "on",
+    thesis: formData.get("thesis"),
+    keyRisks: formData.get("keyRisks"),
+    nextAction: formData.get("nextAction"),
+    description: formData.get("description")
+  });
+
+  if (!parsed.success) {
+    return;
+  }
+
+  const createdAt = now();
+
+  await db.insert(companies).values({
+    id: crypto.randomUUID(),
+    ...parsed.data,
+    stockCode: normalizeCode(parsed.data.stockCode),
+    createdAt,
+    updatedAt: createdAt
+  });
+
+  revalidatePath("/watchlist");
+}
+
+export async function updateCompany(formData: FormData) {
+  const parsed = updateSchema.safeParse({
+    companyId: formData.get("companyId"),
+    stockCode: formData.get("stockCode"),
+    stockName: formData.get("stockName"),
+    exchange: formData.get("exchange"),
+    industry: formData.get("industry"),
+    companyType: formData.get("companyType"),
+    watchStatus: formData.get("watchStatus"),
+    valuationStatus: formData.get("valuationStatus"),
+    inCircle: formData.get("inCircle") === "on",
+    thesis: formData.get("thesis"),
+    keyRisks: formData.get("keyRisks"),
+    nextAction: formData.get("nextAction"),
+    description: formData.get("description")
+  });
+
+  if (!parsed.success) {
+    return;
+  }
+
+  const { companyId, ...values } = parsed.data;
+
+  await db
+    .update(companies)
+    .set({
+      ...values,
+      stockCode: normalizeCode(values.stockCode),
+      updatedAt: now()
+    })
+    .where(eq(companies.id, companyId));
+
+  revalidatePath("/watchlist");
+}

--- a/app/watchlist/page.tsx
+++ b/app/watchlist/page.tsx
@@ -1,11 +1,280 @@
-import { PlaceholderPage } from "@/components/ui/placeholder-page";
+import Link from "next/link";
+import { Bot, Building2, CheckCircle2, ShieldAlert } from "lucide-react";
+import { PendingButton } from "@/components/ui/pending-button";
+import { addCompany, updateCompany } from "./actions";
+import type { companies } from "@/db/schema";
+import {
+  companyTypes,
+  exchanges,
+  labelFor,
+  valuationStatuses,
+  watchStatuses
+} from "@/lib/watchlist/constants";
+import { getWatchlistCompanies } from "@/lib/watchlist/queries";
 
-export default function WatchlistPage() {
+type Company = typeof companies.$inferSelect;
+
+export default async function WatchlistPage() {
+  const watchlist = await getWatchlistCompanies();
+  const circleCount = watchlist.filter((company) => company.inCircle).length;
+
   return (
-    <PlaceholderPage
-      title="观察池"
-      description="用于维护 A 股公司，从观察、深研、等待价格、持有到排除。"
-      items={["公司列表", "研究摘要", "资料来源", "AI 辅助提取"]}
-    />
+    <main className="space-y-8">
+      <section className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-primary">A 股观察池</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-normal">把公司研究放进一条可维护的流水线</h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+              手动维护公司、能力圈、研究状态、估值状态、关键风险和下一步行动。这里不输出买入建议，只帮助你组织研究。
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
+            <Metric label="公司" value={watchlist.length} />
+            <Metric label="能力圈" value={circleCount} />
+            <Metric label="待估值" value={watchlist.filter((company) => company.valuationStatus === "not_started").length} />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[420px_1fr]">
+        <div className="rounded-lg border border-border bg-card p-5">
+          <div className="flex items-center gap-2">
+            <Building2 className="h-5 w-5 text-primary" aria-hidden />
+            <h2 className="text-xl font-semibold">新增公司</h2>
+          </div>
+          <CompanyForm action={addCompany} submitText="加入观察池" />
+        </div>
+
+        <div className="space-y-4">
+          {watchlist.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
+              <p className="font-semibold">观察池还是空的</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                先添加一家公司，例如你正在学习的银行、消费、周期或制造业案例。
+              </p>
+            </div>
+          ) : (
+            watchlist.map((company) => <CompanyCard key={company.id} company={company} />)
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function CompanyCard({ company }: { company: Company }) {
+  const researchDraft = `请作为 A 股研究助理，帮我为 ${company.stockName}（${company.stockCode}）整理研究框架。请区分事实、推断、观点和待确认事项，不要给买入或卖出建议。当前我的记录：行业=${company.industry || "未填写"}，公司类型=${labelFor(companyTypes, company.companyType)}，状态=${labelFor(watchStatuses, company.watchStatus)}，关键风险=${company.keyRisks || "未填写"}。`;
+  const opponentDraft = `请作为投资委员会反方委员，质疑我对 ${company.stockName}（${company.stockCode}）的观察理由。不要给买入卖出建议，请围绕商业模式、财务质量、估值假设、风险和我的能力圈提出追问。我的初步观点：${company.thesis || "暂未填写"}`;
+
+  return (
+    <article className="rounded-lg border border-border bg-card p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2 text-sm font-semibold text-primary">
+            <span>{company.stockCode}</span>
+            <span>/</span>
+            <span>{labelFor(exchanges, company.exchange)}</span>
+            <span>/</span>
+            <span>{labelFor(companyTypes, company.companyType)}</span>
+          </div>
+          <h2 className="mt-2 text-xl font-semibold">{company.stockName}</h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {company.description || "还没有公司简介。"}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <StatusPill label={labelFor(watchStatuses, company.watchStatus)} />
+          <StatusPill label={labelFor(valuationStatuses, company.valuationStatus)} />
+          <StatusPill label={company.inCircle ? "能力圈内" : "能力圈外/待确认"} />
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        <InfoBlock title="投资假设" value={company.thesis || "未填写"} />
+        <InfoBlock title="关键风险" value={company.keyRisks || "未填写"} />
+        <InfoBlock title="下一步行动" value={company.nextAction || "未填写"} />
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Link
+          href={`/mentor?role=research_assistant&draft=${encodeURIComponent(researchDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <Bot className="h-4 w-4" aria-hidden />
+          问研究助理
+        </Link>
+        <Link
+          href={`/mentor?role=opponent&draft=${encodeURIComponent(opponentDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <ShieldAlert className="h-4 w-4" aria-hidden />
+          反方质询
+        </Link>
+      </div>
+
+      <details className="mt-4 rounded-lg border border-border bg-background p-4">
+        <summary className="cursor-pointer text-sm font-semibold">编辑研究状态</summary>
+        <CompanyForm
+          action={updateCompany}
+          company={company}
+          submitText="保存公司记录"
+          className="mt-4"
+        />
+      </details>
+    </article>
+  );
+}
+
+function CompanyForm({
+  action,
+  company,
+  submitText,
+  className = "mt-5"
+}: {
+  action: (formData: FormData) => Promise<void>;
+  company?: Company;
+  submitText: string;
+  className?: string;
+}) {
+  return (
+    <form action={action} className={`${className} space-y-4`}>
+      {company ? <input type="hidden" name="companyId" value={company.id} /> : null}
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="股票代码" name="stockCode" defaultValue={company?.stockCode} placeholder="例如：600519" />
+        <Field label="公司名称" name="stockName" defaultValue={company?.stockName} placeholder="例如：贵州茅台" />
+        <SelectField label="交易所" name="exchange" options={exchanges} defaultValue={company?.exchange ?? "SH"} />
+        <Field label="行业" name="industry" defaultValue={company?.industry} placeholder="例如：白酒 / 银行 / 家电" />
+        <SelectField label="公司类型" name="companyType" options={companyTypes} defaultValue={company?.companyType ?? "other"} />
+        <SelectField label="研究状态" name="watchStatus" options={watchStatuses} defaultValue={company?.watchStatus ?? "watching"} />
+        <SelectField
+          label="估值状态"
+          name="valuationStatus"
+          options={valuationStatuses}
+          defaultValue={company?.valuationStatus ?? "not_started"}
+        />
+        <label className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm">
+          <input name="inCircle" type="checkbox" defaultChecked={company?.inCircle ?? false} />
+          在我的能力圈内
+        </label>
+      </div>
+
+      <TextArea label="公司简介" name="description" defaultValue={company?.description} placeholder="用一两句话描述这家公司靠什么赚钱。" />
+      <TextArea label="投资假设" name="thesis" defaultValue={company?.thesis} placeholder="如果继续研究，它可能值得研究的理由是什么？" />
+      <TextArea label="关键风险" name="keyRisks" defaultValue={company?.keyRisks} placeholder="写下最可能推翻判断的风险。" />
+      <TextArea label="下一步行动" name="nextAction" defaultValue={company?.nextAction} placeholder="例如：阅读年报、补财务数据、做估值、等待价格。" />
+
+      <PendingButton
+        className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+        pendingChildren="保存中..."
+      >
+        <CheckCircle2 className="h-4 w-4" aria-hidden />
+        {submitText}
+      </PendingButton>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  name,
+  defaultValue = "",
+  placeholder
+}: {
+  label: string;
+  name: string;
+  defaultValue?: string;
+  placeholder: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <input
+        name={name}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function SelectField({
+  label,
+  name,
+  options,
+  defaultValue
+}: {
+  label: string;
+  name: string;
+  options: Array<{ value: string; label: string }>;
+  defaultValue: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <select
+        name={name}
+        defaultValue={defaultValue}
+        className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function TextArea({
+  label,
+  name,
+  defaultValue = "",
+  placeholder
+}: {
+  label: string;
+  name: string;
+  defaultValue?: string;
+  placeholder: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <textarea
+        name={name}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        rows={3}
+        className="mt-2 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm leading-6 outline-none transition focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function StatusPill({ label }: { label: string }) {
+  return (
+    <span className="rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-muted-foreground">
+      {label}
+    </span>
+  );
+}
+
+function InfoBlock({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-background p-3">
+      <div className="text-xs font-semibold text-primary">{title}</div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{value}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="min-w-20 rounded-md bg-card px-4 py-3">
+      <div className="text-xl font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{label}</div>
+    </div>
   );
 }

--- a/src/db/migrations/0003_special_iceman.sql
+++ b/src/db/migrations/0003_special_iceman.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `companies` ADD `watch_status` text DEFAULT 'watching' NOT NULL;--> statement-breakpoint
+ALTER TABLE `companies` ADD `valuation_status` text DEFAULT 'not_started' NOT NULL;--> statement-breakpoint
+ALTER TABLE `companies` ADD `in_circle` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `companies` ADD `thesis` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `companies` ADD `key_risks` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `companies` ADD `next_action` text DEFAULT '' NOT NULL;

--- a/src/db/migrations/meta/0003_snapshot.json
+++ b/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,563 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0307ae2f-e36e-4abe-8f04-09cb09915aae",
+  "prevId": "6e22ef4f-df63-4fbf-9b46-be30b5ac340a",
+  "tables": {
+    "ai_conversations": {
+      "name": "ai_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_conversations_provider_id_model_providers_id_fk": {
+          "name": "ai_conversations_provider_id_model_providers_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_messages": {
+      "name": "ai_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_messages_conversation_id_ai_conversations_id_fk": {
+          "name": "ai_messages_conversation_id_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_code": {
+          "name": "stock_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_name": {
+          "name": "stock_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "watch_status": {
+          "name": "watch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'watching'"
+        },
+        "valuation_status": {
+          "name": "valuation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "in_circle": {
+          "name": "in_circle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "thesis": {
+          "name": "thesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "key_risks": {
+          "name": "key_risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_nodes": {
+      "name": "knowledge_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_configs_provider_id_model_providers_id_fk": {
+          "name": "model_configs_provider_id_model_providers_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_providers": {
+      "name": "model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_openai_compatible": {
+          "name": "is_openai_compatible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_insecure_tls": {
+          "name": "allow_insecure_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_name": {
+          "name": "default_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_temperature": {
+          "name": "default_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "max_context_tokens": {
+          "name": "max_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8000
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_tested'"
+        },
+        "last_test_message": {
+          "name": "last_test_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777699350416,
       "tag": "0002_rare_raider",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1777704799445,
+      "tag": "0003_special_iceman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -73,6 +73,12 @@ export const companies = sqliteTable("companies", {
   exchange: text("exchange").notNull(),
   industry: text("industry").notNull().default(""),
   companyType: text("company_type").notNull().default("other"),
+  watchStatus: text("watch_status").notNull().default("watching"),
+  valuationStatus: text("valuation_status").notNull().default("not_started"),
+  inCircle: integer("in_circle", { mode: "boolean" }).notNull().default(false),
+  thesis: text("thesis").notNull().default(""),
+  keyRisks: text("key_risks").notNull().default(""),
+  nextAction: text("next_action").notNull().default(""),
   description: text("description").notNull().default(""),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull()

--- a/src/lib/watchlist/constants.ts
+++ b/src/lib/watchlist/constants.ts
@@ -1,0 +1,34 @@
+export const exchanges = [
+  { value: "SH", label: "上交所" },
+  { value: "SZ", label: "深交所" },
+  { value: "BJ", label: "北交所" }
+];
+
+export const companyTypes = [
+  { value: "consumer", label: "消费" },
+  { value: "financial", label: "金融" },
+  { value: "cyclical", label: "周期" },
+  { value: "manufacturing", label: "制造" },
+  { value: "healthcare", label: "医药" },
+  { value: "technology", label: "科技" },
+  { value: "other", label: "其他" }
+];
+
+export const watchStatuses = [
+  { value: "watching", label: "观察中" },
+  { value: "researching", label: "深研中" },
+  { value: "waiting_price", label: "等待价格" },
+  { value: "holding", label: "已持有" },
+  { value: "excluded", label: "已排除" }
+];
+
+export const valuationStatuses = [
+  { value: "not_started", label: "未估值" },
+  { value: "rough", label: "粗估完成" },
+  { value: "scenario", label: "三情景完成" },
+  { value: "needs_review", label: "待复核" }
+];
+
+export function labelFor(options: Array<{ value: string; label: string }>, value: string) {
+  return options.find((option) => option.value === value)?.label ?? value;
+}

--- a/src/lib/watchlist/queries.ts
+++ b/src/lib/watchlist/queries.ts
@@ -1,0 +1,7 @@
+import { desc } from "drizzle-orm";
+import { db } from "@/db/client";
+import { companies } from "@/db/schema";
+
+export async function getWatchlistCompanies() {
+  return db.select().from(companies).orderBy(desc(companies.updatedAt));
+}


### PR DESCRIPTION
## 关联 Issue\n\nCloses #9\n\n## 改动摘要\n\n- 将观察池占位页升级为可用的 A 股公司研究工作台。\n- 支持手动新增和编辑公司记录，维护研究状态、估值状态、能力圈、投资假设、关键风险和下一步行动。\n- 为每家公司提供 AI 研究助理和投资委员会反方质询入口，沿用现有导师页面 draft 参数。\n\n## 主要文件\n\n- app/watchlist/page.tsx\n- app/watchlist/actions.ts\n- src/lib/watchlist/constants.ts\n- src/lib/watchlist/queries.ts\n- src/db/schema.ts\n- src/db/migrations/0003_special_iceman.sql\n\n## 验证\n\n- [x] npm run db:generate\n- [x] npm run db:migrate\n- [x] npm run typecheck\n- [x] npm run build\n- [x] 重启 next dev 后验证 /watchlist 返回 200\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n\n## 截图 / 说明\n\n本次为本地 MVP 页面：观察池为空时显示空状态；添加公司后以卡片展示研究状态、估值状态、能力圈、投资假设、关键风险和下一步行动。\n\n## 数据库迁移\n\n新增 companies 字段：watch_status、valuation_status、in_circle、thesis、key_risks、next_action。所有字段都有默认值，已有本地公司数据可迁移。\n\n## 风险\n\n- 当前表单验证失败时只静默返回，后续可增加页面级错误提示。\n- 第一版不提供删除，避免误删本地研究记录。\n\n## 回退方案\n\n回退本 PR 可恢复观察池占位页；如本地已执行迁移，旧代码会忽略新增字段。