### PR TITLE
feat: add investment system MVP

### DIFF
--- a/app/system/actions.ts
+++ b/app/system/actions.ts
@@ -1,0 +1,171 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { checklistRuns, decisions, investmentPrinciples } from "@/db/schema";
+import { checklistTemplates, checklistTypes, labelFor } from "@/lib/investment-system/constants";
+import { getActiveInvestmentPrinciple } from "@/lib/investment-system/queries";
+
+const principleSchema = z.object({
+  principleId: z.string().optional(),
+  title: z.string().trim().min(1, "请填写原则名称。"),
+  circleOfCompetence: z.string().trim().default(""),
+  excludedIndustries: z.string().trim().default(""),
+  minimumFinancialQuality: z.string().trim().default(""),
+  minimumMarginOfSafety: z.string().trim().default(""),
+  positionRules: z.string().trim().default(""),
+  buyRules: z.string().trim().default(""),
+  sellRules: z.string().trim().default(""),
+  doNothingRules: z.string().trim().default(""),
+  riskRules: z.string().trim().default("")
+});
+
+const runSchema = z.object({
+  checklistType: z.enum(["buy", "sell", "do_nothing"]),
+  companyId: z.string().trim().optional(),
+  finalJudgment: z.string().trim().min(1, "请填写你自己的最终判断。"),
+  keyAssumptions: z.string().trim().default(""),
+  risks: z.string().trim().default(""),
+  summary: z.string().trim().default("")
+});
+
+function now() {
+  return new Date().toISOString();
+}
+
+function statusRedirect(status: string, message: string): never {
+  redirect(`/system?status=${encodeURIComponent(status)}&message=${encodeURIComponent(message)}`);
+}
+
+export async function saveInvestmentPrinciple(formData: FormData) {
+  const parsed = principleSchema.safeParse({
+    principleId: String(formData.get("principleId") ?? "").trim() || undefined,
+    title: formData.get("title"),
+    circleOfCompetence: formData.get("circleOfCompetence"),
+    excludedIndustries: formData.get("excludedIndustries"),
+    minimumFinancialQuality: formData.get("minimumFinancialQuality"),
+    minimumMarginOfSafety: formData.get("minimumMarginOfSafety"),
+    positionRules: formData.get("positionRules"),
+    buyRules: formData.get("buyRules"),
+    sellRules: formData.get("sellRules"),
+    doNothingRules: formData.get("doNothingRules"),
+    riskRules: formData.get("riskRules")
+  });
+
+  if (!parsed.success) {
+    statusRedirect("error", parsed.error.issues[0]?.message ?? "投资原则校验失败。");
+  }
+
+  const updatedAt = now();
+
+  if (parsed.data.principleId) {
+    const { principleId, ...values } = parsed.data;
+    await db
+      .update(investmentPrinciples)
+      .set({
+        ...values,
+        version: 1,
+        active: true,
+        updatedAt
+      })
+      .where(eq(investmentPrinciples.id, principleId));
+  } else {
+    await db.insert(investmentPrinciples).values({
+      id: crypto.randomUUID(),
+      title: parsed.data.title,
+      circleOfCompetence: parsed.data.circleOfCompetence,
+      excludedIndustries: parsed.data.excludedIndustries,
+      minimumFinancialQuality: parsed.data.minimumFinancialQuality,
+      minimumMarginOfSafety: parsed.data.minimumMarginOfSafety,
+      positionRules: parsed.data.positionRules,
+      buyRules: parsed.data.buyRules,
+      sellRules: parsed.data.sellRules,
+      doNothingRules: parsed.data.doNothingRules,
+      riskRules: parsed.data.riskRules,
+      version: 1,
+      active: true,
+      createdAt: updatedAt,
+      updatedAt
+    });
+  }
+
+  revalidatePath("/system");
+  statusRedirect("success", "投资原则已保存。");
+}
+
+export async function saveChecklistRun(formData: FormData) {
+  const parsed = runSchema.safeParse({
+    checklistType: formData.get("checklistType"),
+    companyId: String(formData.get("companyId") ?? "").trim() || undefined,
+    finalJudgment: formData.get("finalJudgment"),
+    keyAssumptions: formData.get("keyAssumptions"),
+    risks: formData.get("risks"),
+    summary: formData.get("summary")
+  });
+
+  if (!parsed.success) {
+    statusRedirect("error", parsed.error.issues[0]?.message ?? "检查清单校验失败。");
+  }
+
+  const template = checklistTemplates[parsed.data.checklistType];
+  const items = template.map((item) => {
+    const status = String(formData.get(`status.${item.id}`) ?? "unknown");
+    const normalizedStatus = ["pass", "fail", "unknown", "not_applicable"].includes(status)
+      ? status
+      : "unknown";
+
+    return {
+      id: item.id,
+      text: item.text,
+      category: item.category,
+      required: item.required,
+      status: normalizedStatus,
+      note: String(formData.get(`note.${item.id}`) ?? "").trim()
+    };
+  });
+
+  const requiredIssues = items.filter(
+    (item) => item.required && (item.status === "fail" || item.status === "unknown")
+  );
+  const principle = await getActiveInvestmentPrinciple();
+  const timestamp = now();
+  const checklistRunId = crypto.randomUUID();
+  const decisionId = crypto.randomUUID();
+  const checklistLabel = labelFor(checklistTypes, parsed.data.checklistType);
+  const summary =
+    parsed.data.summary ||
+    `完成${checklistLabel}，关键未确认/失败项 ${requiredIssues.length} 项。`;
+
+  await db.insert(checklistRuns).values({
+    id: checklistRunId,
+    checklistType: parsed.data.checklistType,
+    companyId: parsed.data.companyId ?? null,
+    principleId: principle?.id ?? null,
+    itemsJson: JSON.stringify(items),
+    summary,
+    finalJudgment: parsed.data.finalJudgment,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  await db.insert(decisions).values({
+    id: decisionId,
+    companyId: parsed.data.companyId ?? null,
+    checklistRunId,
+    principleId: principle?.id ?? null,
+    decisionType: parsed.data.checklistType,
+    finalUserJudgment: parsed.data.finalJudgment,
+    keyAssumptions: parsed.data.keyAssumptions,
+    risks: parsed.data.risks,
+    opponentSummary: "",
+    decisionDate: timestamp.slice(0, 10),
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  revalidatePath("/system");
+  statusRedirect("success", "检查清单和决策记录已保存。");
+}

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -1,11 +1,419 @@
-import { PlaceholderPage } from "@/components/ui/placeholder-page";
+import Link from "next/link";
+import {
+  AlertCircle,
+  Bot,
+  CheckCircle2,
+  ClipboardCheck,
+  FilePenLine,
+  History,
+  ShieldAlert
+} from "lucide-react";
+import { PendingButton } from "@/components/ui/pending-button";
+import { SectionHeader } from "@/components/ui/section-header";
+import type { checklistRuns, companies, decisions, investmentPrinciples } from "@/db/schema";
+import {
+  checklistStatuses,
+  checklistTemplates,
+  checklistTypes,
+  labelFor,
+  type ChecklistTemplateItem,
+  type ChecklistType
+} from "@/lib/investment-system/constants";
+import { getSystemPageData } from "@/lib/investment-system/queries";
+import { saveChecklistRun, saveInvestmentPrinciple } from "./actions";
 
-export default function SystemPage() {
+type SystemPageProps = {
+  searchParams?: Promise<{
+    status?: string;
+    message?: string;
+  }>;
+};
+
+type Company = typeof companies.$inferSelect;
+type Principle = typeof investmentPrinciples.$inferSelect;
+type Run = typeof checklistRuns.$inferSelect;
+type Decision = typeof decisions.$inferSelect;
+
+type RunItem = ChecklistTemplateItem & {
+  status: string;
+  note: string;
+};
+
+export default async function SystemPage({ searchParams }: SystemPageProps) {
+  const paramsPromise: Promise<{ status?: string; message?: string }> = searchParams ?? Promise.resolve({});
+  const [params, data] = await Promise.all([paramsPromise, getSystemPageData()]);
+
   return (
-    <PlaceholderPage
-      title="投资系统"
-      description="把投资原则、买入检查、卖出检查、不操作检查和决策日志串成流程。"
-      items={["投资原则", "买入检查", "卖出检查", "不操作检查", "决策日志"]}
-    />
+    <main className="space-y-8">
+      <section className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <SectionHeader
+            title="投资系统"
+            description="把你的原则、清单和最终判断固定成流程：先检查，再记录，最后复盘。AI 只负责追问和反驳，不替你做买卖结论。"
+          />
+          <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
+            <Metric label="原则" value={data.principle ? 1 : 0} />
+            <Metric label="检查" value={data.recentRuns.length} />
+            <Metric label="决策" value={data.recentDecisions.length} />
+          </div>
+        </div>
+      </section>
+
+      {params.message ? (
+        <StatusBanner status={params.status === "success" ? "success" : "error"} message={params.message} />
+      ) : null}
+
+      <section className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+        <PrinciplePanel principle={data.principle} />
+        <ChecklistPanel principle={data.principle} companies={data.companies} />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <RecentRuns runs={data.recentRuns} principle={data.principle} />
+        <DecisionLog decisions={data.recentDecisions} />
+      </section>
+    </main>
   );
+}
+
+function PrinciplePanel({ principle }: { principle?: Principle }) {
+  const auditDraft = `请作为投资委员会反方委员，检查我的 A 股价值投资原则是否足够清晰、可执行、可反证。不要替我制定最终原则，也不要给买卖建议。我的原则如下：能力圈=${principle?.circleOfCompetence || "未填写"}；不碰行业=${principle?.excludedIndustries || "未填写"}；财务质量=${principle?.minimumFinancialQuality || "未填写"}；安全边际=${principle?.minimumMarginOfSafety || "未填写"}；买入规则=${principle?.buyRules || "未填写"}；卖出规则=${principle?.sellRules || "未填写"}；不操作规则=${principle?.doNothingRules || "未填写"}。`;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-center gap-2">
+          <FilePenLine className="h-5 w-5 text-primary" aria-hidden />
+          <h2 className="text-xl font-semibold">投资原则</h2>
+        </div>
+        <Link
+          href={`/mentor?role=opponent&draft=${encodeURIComponent(auditDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <ShieldAlert className="h-4 w-4" aria-hidden />
+          让反方委员检查原则
+        </Link>
+      </div>
+
+      <form action={saveInvestmentPrinciple} className="mt-5 space-y-4">
+        {principle ? <input type="hidden" name="principleId" value={principle.id} /> : null}
+        <Field label="原则名称" name="title" defaultValue={principle?.title ?? "我的 A 股价值投资原则"} />
+        <TextArea label="能力圈" name="circleOfCompetence" defaultValue={principle?.circleOfCompetence} placeholder="我能理解哪些行业、商业模式和财务指标？哪些暂时看不懂？" />
+        <TextArea label="不碰行业 / 情形" name="excludedIndustries" defaultValue={principle?.excludedIndustries} placeholder="例如：看不懂的高杠杆、治理差、财报质量不可信、商业模式快速变化等。" />
+        <TextArea label="财务质量底线" name="minimumFinancialQuality" defaultValue={principle?.minimumFinancialQuality} placeholder="例如：现金流、负债率、ROE 稳定性、应收账款、资本开支等底线。" />
+        <TextArea label="安全边际要求" name="minimumMarginOfSafety" defaultValue={principle?.minimumMarginOfSafety} placeholder="不同类型公司需要多大折扣、哪些假设必须保守？" />
+        <TextArea label="仓位规则" name="positionRules" defaultValue={principle?.positionRules} placeholder="单家公司、单一行业、现金比例和加减仓约束。" />
+        <div className="grid gap-4 md:grid-cols-3">
+          <TextArea label="买入规则" name="buyRules" defaultValue={principle?.buyRules} placeholder="什么条件都满足后才允许进入下一步？" />
+          <TextArea label="卖出规则" name="sellRules" defaultValue={principle?.sellRules} placeholder="假设破裂、基本面恶化、估值过高或更好机会如何处理？" />
+          <TextArea label="不操作规则" name="doNothingRules" defaultValue={principle?.doNothingRules} placeholder="什么情况下继续观察、等待价格或补证据？" />
+        </div>
+        <TextArea label="风险规则" name="riskRules" defaultValue={principle?.riskRules} placeholder="哪些风险必须写清？哪些风险一出现就暂停决策？" />
+
+        <PendingButton
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+          pendingChildren="保存中..."
+        >
+          <CheckCircle2 className="h-4 w-4" aria-hidden />
+          保存投资原则
+        </PendingButton>
+      </form>
+    </section>
+  );
+}
+
+function ChecklistPanel({ principle, companies }: { principle?: Principle; companies: Company[] }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <ClipboardCheck className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">决策检查清单</h2>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        选择一家公司，完成买入、卖出或不操作检查。最终判断必须由你填写，系统只记录流程证据。
+      </p>
+
+      {!principle ? (
+        <div className="mt-4 rounded-lg border border-border bg-background p-4 text-sm leading-6 text-muted-foreground">
+          建议先保存投资原则，再运行检查清单。MVP 允许先跑清单，但原则缺失会降低复盘质量。
+        </div>
+      ) : null}
+
+      <div className="mt-5 space-y-5">
+        {checklistTypes.map((type) => (
+          <ChecklistForm key={type.value} type={type.value as ChecklistType} companies={companies} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ChecklistForm({ type, companies }: { type: ChecklistType; companies: Company[] }) {
+  const template = checklistTemplates[type];
+  const typeMeta = checklistTypes.find((item) => item.value === type);
+
+  return (
+    <details className="rounded-lg border border-border bg-background p-4" open={type === "buy"}>
+      <summary className="cursor-pointer text-sm font-semibold">{typeMeta?.label ?? type}</summary>
+      <form action={saveChecklistRun} className="mt-4 space-y-4">
+        <input type="hidden" name="checklistType" value={type} />
+        <label className="block">
+          <span className="text-sm font-semibold">关联公司</span>
+          <select
+            name="companyId"
+            className="mt-2 w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none transition focus:border-primary"
+          >
+            <option value="">不关联公司</option>
+            {companies.map((company) => (
+              <option key={company.id} value={company.id}>
+                {company.stockName}（{company.stockCode}）
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="space-y-3">
+          {template.map((item) => (
+            <ChecklistItem key={item.id} item={item} />
+          ))}
+        </div>
+
+        <TextArea label="关键假设" name="keyAssumptions" placeholder="写下这次判断最依赖的 1-3 个假设。" />
+        <TextArea label="主要风险" name="risks" placeholder="写下最可能推翻这次判断的风险。" />
+        <TextArea label="检查摘要" name="summary" placeholder="可选：概括这次检查的核心结论和未确认事项。" />
+        <TextArea label={typeMeta?.decisionLabel ?? "用户最终判断"} name="finalJudgment" placeholder="必须由你自己填写，例如：继续研究、等待价格、排除、纳入候选等。不需要写买卖建议。" />
+
+        <PendingButton
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+          pendingChildren="保存中..."
+        >
+          <CheckCircle2 className="h-4 w-4" aria-hidden />
+          保存检查和决策记录
+        </PendingButton>
+      </form>
+    </details>
+  );
+}
+
+function ChecklistItem({ item }: { item: ChecklistTemplateItem }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-primary">
+            <span>{item.category}</span>
+            {item.required ? <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">关键项</span> : null}
+          </div>
+          <p className="mt-2 text-sm leading-6">{item.text}</p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {checklistStatuses.map((status) => (
+            <label key={status.value} className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1">
+              <input
+                type="radio"
+                name={`status.${item.id}`}
+                value={status.value}
+                defaultChecked={status.value === "unknown"}
+              />
+              {status.label}
+            </label>
+          ))}
+        </div>
+      </div>
+      <input
+        name={`note.${item.id}`}
+        placeholder="备注：证据、反例或待确认事项"
+        className="mt-3 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+      />
+    </div>
+  );
+}
+
+function RecentRuns({
+  runs,
+  principle
+}: {
+  runs: Array<{ run: Run; company: Company | null }>;
+  principle?: Principle;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <History className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">最近检查</h2>
+      </div>
+      <div className="mt-5 space-y-3">
+        {runs.length === 0 ? (
+          <EmptyState text="还没有检查记录。先完成一次买入、卖出或不操作检查。" />
+        ) : (
+          runs.map(({ run, company }) => (
+            <RunCard key={run.id} run={run} company={company} principle={principle} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function RunCard({ run, company, principle }: { run: Run; company: Company | null; principle?: Principle }) {
+  const items = parseRunItems(run.itemsJson);
+  const issueCount = items.filter((item) => item.required && (item.status === "fail" || item.status === "unknown")).length;
+  const opponentDraft = `请作为投资委员会反方委员，审阅我的${labelFor(checklistTypes, run.checklistType)}记录。不要给买入或卖出建议，只提出反方问题、遗漏证据和原则冲突。公司=${company ? `${company.stockName}（${company.stockCode}）` : "未关联"}；检查摘要=${run.summary}；最终判断=${run.finalJudgment}；当前原则=${principle?.title || "未保存原则"}。检查项=${items.map((item) => `${item.text}：${labelFor(checklistStatuses, item.status)}${item.note ? `，备注：${item.note}` : ""}`).join("；")}`;
+
+  return (
+    <article className="rounded-lg border border-border bg-background p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="text-sm font-semibold">{labelFor(checklistTypes, run.checklistType)}</div>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {company ? `${company.stockName}（${company.stockCode}）` : "未关联公司"} / {run.createdAt.slice(0, 10)}
+          </p>
+        </div>
+        <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+          关键问题 {issueCount} 项
+        </span>
+      </div>
+      <p className="mt-3 text-sm leading-6">{run.summary}</p>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">最终判断：{run.finalJudgment}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {items.slice(0, 4).map((item) => (
+          <span key={item.id} className="rounded-full border border-border bg-card px-2 py-1 text-xs text-muted-foreground">
+            {item.category}：{labelFor(checklistStatuses, item.status)}
+          </span>
+        ))}
+      </div>
+      <Link
+        href={`/mentor?role=opponent&draft=${encodeURIComponent(opponentDraft)}`}
+        className="mt-3 inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+      >
+        <Bot className="h-4 w-4" aria-hidden />
+        请求反方审阅
+      </Link>
+    </article>
+  );
+}
+
+function DecisionLog({ decisions }: { decisions: Array<{ decision: Decision; company: Company | null }> }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <ClipboardCheck className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">决策日志</h2>
+      </div>
+      <div className="mt-5 space-y-3">
+        {decisions.length === 0 ? (
+          <EmptyState text="还没有决策日志。完成检查清单后会自动生成一条用户判断记录。" />
+        ) : (
+          decisions.map(({ decision, company }) => (
+            <article key={decision.id} className="rounded-lg border border-border bg-background p-4">
+              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div className="text-sm font-semibold">{labelFor(checklistTypes, decision.decisionType)}</div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {company ? `${company.stockName}（${company.stockCode}）` : "未关联公司"} / {decision.decisionDate}
+                  </p>
+                </div>
+                <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+                  用户填写
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6">{decision.finalUserJudgment}</p>
+              {decision.keyAssumptions || decision.risks ? (
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <InfoBlock title="关键假设" value={decision.keyAssumptions || "未填写"} />
+                  <InfoBlock title="主要风险" value={decision.risks || "未填写"} />
+                </div>
+              ) : null}
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Field({ label, name, defaultValue = "" }: { label: string; name: string; defaultValue?: string }) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <input
+        name={name}
+        defaultValue={defaultValue}
+        className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function TextArea({
+  label,
+  name,
+  defaultValue = "",
+  placeholder
+}: {
+  label: string;
+  name: string;
+  defaultValue?: string;
+  placeholder: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <textarea
+        name={name}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        rows={3}
+        className="mt-2 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm leading-6 outline-none transition focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function StatusBanner({ status, message }: { status: "success" | "error"; message: string }) {
+  const Icon = status === "success" ? CheckCircle2 : AlertCircle;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <Icon className="mt-0.5 h-5 w-5 text-primary" aria-hidden />
+        <p className="text-sm leading-6">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-background p-6 text-sm leading-6 text-muted-foreground">
+      {text}
+    </div>
+  );
+}
+
+function InfoBlock({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="text-xs font-semibold text-primary">{title}</div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{value}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="min-w-20 rounded-md bg-card px-4 py-3">
+      <div className="text-xl font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+function parseRunItems(value: string): RunItem[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 }

--- a/src/db/migrations/0004_stale_crystal.sql
+++ b/src/db/migrations/0004_stale_crystal.sql
@@ -1,0 +1,49 @@
+CREATE TABLE `checklist_runs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`checklist_type` text NOT NULL,
+	`company_id` text,
+	`principle_id` text,
+	`items_json` text DEFAULT '[]' NOT NULL,
+	`summary` text DEFAULT '' NOT NULL,
+	`final_judgment` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`principle_id`) REFERENCES `investment_principles`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `decisions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`company_id` text,
+	`checklist_run_id` text,
+	`principle_id` text,
+	`decision_type` text NOT NULL,
+	`final_user_judgment` text NOT NULL,
+	`key_assumptions` text DEFAULT '' NOT NULL,
+	`risks` text DEFAULT '' NOT NULL,
+	`opponent_summary` text DEFAULT '' NOT NULL,
+	`decision_date` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`checklist_run_id`) REFERENCES `checklist_runs`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`principle_id`) REFERENCES `investment_principles`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `investment_principles` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text DEFAULT '我的 A 股价值投资原则' NOT NULL,
+	`circle_of_competence` text DEFAULT '' NOT NULL,
+	`excluded_industries` text DEFAULT '' NOT NULL,
+	`minimum_financial_quality` text DEFAULT '' NOT NULL,
+	`minimum_margin_of_safety` text DEFAULT '' NOT NULL,
+	`position_rules` text DEFAULT '' NOT NULL,
+	`buy_rules` text DEFAULT '' NOT NULL,
+	`sell_rules` text DEFAULT '' NOT NULL,
+	`do_nothing_rules` text DEFAULT '' NOT NULL,
+	`risk_rules` text DEFAULT '' NOT NULL,
+	`version` integer DEFAULT 1 NOT NULL,
+	`active` integer DEFAULT true NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);

--- a/src/db/migrations/meta/0004_snapshot.json
+++ b/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,929 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d49ecdf9-4b32-450b-985c-ebedeeb3d801",
+  "prevId": "0307ae2f-e36e-4abe-8f04-09cb09915aae",
+  "tables": {
+    "ai_conversations": {
+      "name": "ai_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_conversations_provider_id_model_providers_id_fk": {
+          "name": "ai_conversations_provider_id_model_providers_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_messages": {
+      "name": "ai_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_messages_conversation_id_ai_conversations_id_fk": {
+          "name": "ai_messages_conversation_id_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checklist_runs": {
+      "name": "checklist_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_type": {
+          "name": "checklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "final_judgment": {
+          "name": "final_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_runs_company_id_companies_id_fk": {
+          "name": "checklist_runs_company_id_companies_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "checklist_runs_principle_id_investment_principles_id_fk": {
+          "name": "checklist_runs_principle_id_investment_principles_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_code": {
+          "name": "stock_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_name": {
+          "name": "stock_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "watch_status": {
+          "name": "watch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'watching'"
+        },
+        "valuation_status": {
+          "name": "valuation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "in_circle": {
+          "name": "in_circle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "thesis": {
+          "name": "thesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "key_risks": {
+          "name": "key_risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decisions": {
+      "name": "decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checklist_run_id": {
+          "name": "checklist_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_type": {
+          "name": "decision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "final_user_judgment": {
+          "name": "final_user_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_assumptions": {
+          "name": "key_assumptions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risks": {
+          "name": "risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "opponent_summary": {
+          "name": "opponent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "decision_date": {
+          "name": "decision_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "decisions_company_id_companies_id_fk": {
+          "name": "decisions_company_id_companies_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_checklist_run_id_checklist_runs_id_fk": {
+          "name": "decisions_checklist_run_id_checklist_runs_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "checklist_runs",
+          "columnsFrom": [
+            "checklist_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_principle_id_investment_principles_id_fk": {
+          "name": "decisions_principle_id_investment_principles_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "investment_principles": {
+      "name": "investment_principles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'我的 A 股价值投资原则'"
+        },
+        "circle_of_competence": {
+          "name": "circle_of_competence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "excluded_industries": {
+          "name": "excluded_industries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_financial_quality": {
+          "name": "minimum_financial_quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_margin_of_safety": {
+          "name": "minimum_margin_of_safety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_rules": {
+          "name": "position_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "buy_rules": {
+          "name": "buy_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sell_rules": {
+          "name": "sell_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_nothing_rules": {
+          "name": "do_nothing_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risk_rules": {
+          "name": "risk_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_nodes": {
+      "name": "knowledge_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_configs_provider_id_model_providers_id_fk": {
+          "name": "model_configs_provider_id_model_providers_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_providers": {
+      "name": "model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_openai_compatible": {
+          "name": "is_openai_compatible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_insecure_tls": {
+          "name": "allow_insecure_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_name": {
+          "name": "default_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_temperature": {
+          "name": "default_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "max_context_tokens": {
+          "name": "max_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8000
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_tested'"
+        },
+        "last_test_message": {
+          "name": "last_test_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777704799445,
       "tag": "0003_special_iceman",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777705339999,
+      "tag": "0004_stale_crystal",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -83,3 +83,48 @@ export const companies = sqliteTable("companies", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull()
 });
+
+export const investmentPrinciples = sqliteTable("investment_principles", {
+  id: text("id").primaryKey(),
+  title: text("title").notNull().default("我的 A 股价值投资原则"),
+  circleOfCompetence: text("circle_of_competence").notNull().default(""),
+  excludedIndustries: text("excluded_industries").notNull().default(""),
+  minimumFinancialQuality: text("minimum_financial_quality").notNull().default(""),
+  minimumMarginOfSafety: text("minimum_margin_of_safety").notNull().default(""),
+  positionRules: text("position_rules").notNull().default(""),
+  buyRules: text("buy_rules").notNull().default(""),
+  sellRules: text("sell_rules").notNull().default(""),
+  doNothingRules: text("do_nothing_rules").notNull().default(""),
+  riskRules: text("risk_rules").notNull().default(""),
+  version: integer("version").notNull().default(1),
+  active: integer("active", { mode: "boolean" }).notNull().default(true),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const checklistRuns = sqliteTable("checklist_runs", {
+  id: text("id").primaryKey(),
+  checklistType: text("checklist_type").notNull(),
+  companyId: text("company_id").references(() => companies.id, { onDelete: "set null" }),
+  principleId: text("principle_id").references(() => investmentPrinciples.id, { onDelete: "set null" }),
+  itemsJson: text("items_json").notNull().default("[]"),
+  summary: text("summary").notNull().default(""),
+  finalJudgment: text("final_judgment").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const decisions = sqliteTable("decisions", {
+  id: text("id").primaryKey(),
+  companyId: text("company_id").references(() => companies.id, { onDelete: "set null" }),
+  checklistRunId: text("checklist_run_id").references(() => checklistRuns.id, { onDelete: "set null" }),
+  principleId: text("principle_id").references(() => investmentPrinciples.id, { onDelete: "set null" }),
+  decisionType: text("decision_type").notNull(),
+  finalUserJudgment: text("final_user_judgment").notNull(),
+  keyAssumptions: text("key_assumptions").notNull().default(""),
+  risks: text("risks").notNull().default(""),
+  opponentSummary: text("opponent_summary").notNull().default(""),
+  decisionDate: text("decision_date").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});

--- a/src/lib/investment-system/constants.ts
+++ b/src/lib/investment-system/constants.ts
@@ -1,0 +1,50 @@
+export const checklistStatuses = [
+  { value: "pass", label: "通过", tone: "text-emerald-700" },
+  { value: "fail", label: "失败", tone: "text-red-700" },
+  { value: "unknown", label: "未知", tone: "text-amber-700" },
+  { value: "not_applicable", label: "不适用", tone: "text-muted-foreground" }
+];
+
+export const checklistTypes = [
+  { value: "buy", label: "买入检查", decisionLabel: "用户买入前判断" },
+  { value: "sell", label: "卖出检查", decisionLabel: "用户卖出前判断" },
+  { value: "do_nothing", label: "不操作检查", decisionLabel: "用户不操作判断" }
+];
+
+export type ChecklistType = (typeof checklistTypes)[number]["value"];
+
+export type ChecklistTemplateItem = {
+  id: string;
+  text: string;
+  category: string;
+  required: boolean;
+};
+
+export const checklistTemplates: Record<ChecklistType, ChecklistTemplateItem[]> = {
+  buy: [
+    { id: "circle", text: "公司是否在我的能力圈内，且我能解释它靠什么赚钱？", category: "能力圈", required: true },
+    { id: "business", text: "商业模式、竞争优势和行业结构是否经得起反方质疑？", category: "商业质量", required: true },
+    { id: "financial", text: "财务质量是否满足原则中的最低标准，现金流和负债是否可接受？", category: "财务质量", required: true },
+    { id: "valuation", text: "估值是否有明确假设、区间和足够安全边际？", category: "估值纪律", required: true },
+    { id: "risk", text: "最关键风险是否已经写清，并且知道什么事实会推翻判断？", category: "风险", required: true },
+    { id: "position", text: "仓位是否符合单一公司、行业和组合风险规则？", category: "仓位", required: false }
+  ],
+  sell: [
+    { id: "thesis_broken", text: "最初投资假设是否已经被事实推翻？", category: "假设", required: true },
+    { id: "fundamental", text: "商业模式、财务质量或治理是否出现持续恶化？", category: "基本面", required: true },
+    { id: "valuation_high", text: "当前估值是否明显透支未来回报，且安全边际已经消失？", category: "估值", required: true },
+    { id: "better_use", text: "是否有更符合原则、风险收益更清晰的资金用途？", category: "机会成本", required: false },
+    { id: "emotion", text: "这个动作是否不是因为短期波动、恐惧或厌烦而做？", category: "纪律", required: true }
+  ],
+  do_nothing: [
+    { id: "insufficient_info", text: "关键信息是否不足，继续研究比马上行动更合理？", category: "证据", required: true },
+    { id: "price_unattractive", text: "价格是否没有给出足够安全边际？", category: "价格", required: true },
+    { id: "outside_circle", text: "公司是否暂时超出能力圈，无法判断关键变量？", category: "能力圈", required: false },
+    { id: "no_forced_action", text: "我是否没有为了参与行情、回本或证明自己而强行动作？", category: "行为纪律", required: true },
+    { id: "next_action", text: "是否写清下一步观察事项、触发条件或复查时间？", category: "下一步", required: true }
+  ]
+};
+
+export function labelFor<T extends { value: string; label: string }>(options: T[], value: string) {
+  return options.find((option) => option.value === value)?.label ?? value;
+}

--- a/src/lib/investment-system/queries.ts
+++ b/src/lib/investment-system/queries.ts
@@ -1,0 +1,46 @@
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { checklistRuns, companies, decisions, investmentPrinciples } from "@/db/schema";
+
+export async function getActiveInvestmentPrinciple() {
+  const [principle] = await db
+    .select()
+    .from(investmentPrinciples)
+    .where(eq(investmentPrinciples.active, true))
+    .orderBy(desc(investmentPrinciples.updatedAt))
+    .limit(1);
+
+  return principle;
+}
+
+export async function getSystemPageData() {
+  const [principle, companyRows, runRows, decisionRows] = await Promise.all([
+    getActiveInvestmentPrinciple(),
+    db.select().from(companies).orderBy(desc(companies.updatedAt)),
+    db
+      .select({
+        run: checklistRuns,
+        company: companies
+      })
+      .from(checklistRuns)
+      .leftJoin(companies, eq(checklistRuns.companyId, companies.id))
+      .orderBy(desc(checklistRuns.createdAt))
+      .limit(6),
+    db
+      .select({
+        decision: decisions,
+        company: companies
+      })
+      .from(decisions)
+      .leftJoin(companies, eq(decisions.companyId, companies.id))
+      .orderBy(desc(decisions.createdAt))
+      .limit(6)
+  ]);
+
+  return {
+    principle,
+    companies: companyRows,
+    recentRuns: runRows,
+    recentDecisions: decisionRows
+  };
+}


### PR DESCRIPTION
## 关联 Issue\n\nCloses #11\n\n## 改动摘要\n\n- 将投资系统占位页升级为可用的流程工作台。\n- 支持保存和编辑当前投资原则：能力圈、不碰行业、财务质量、安全边际、仓位、买入、卖出、不操作和风险规则。\n- 支持买入、卖出、不操作三类检查清单，检查项可标记通过、失败、未知或不适用。\n- 保存检查清单时同步生成用户决策日志，最终判断必须由用户填写。\n- 最近检查提供 AI 反方委员审阅入口，但不输出买卖建议。\n\n## 主要文件\n\n- app/system/page.tsx\n- app/system/actions.ts\n- src/lib/investment-system/constants.ts\n- src/lib/investment-system/queries.ts\n- src/db/schema.ts\n- src/db/migrations/0004_stale_crystal.sql\n\n## 验证\n\n- [x] npm run db:generate\n- [x] npm run db:migrate\n- [x] npm run typecheck\n- [x] npm run build\n- [x] 重启 next dev 后验证 /system 返回 200\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n\n## 截图 / 说明\n\n/system 页面包含四个核心区域：投资原则、决策检查清单、最近检查、决策日志。第一版优先保证本地闭环可用。\n\n## 数据库迁移\n\n新增 investment_principles、checklist_runs、decisions 三张表。新增表不影响已有模型配置、学习、训练、观察池数据。\n\n## 风险\n\n- 第一版检查清单模板是固定模板，后续需要支持用户自定义。\n- 第一版决策日志在 /system 中展示摘要，完整详情和复盘入口放后续 Issue。\n\n## 回退方案\n\n回退本 PR 可恢复投资系统占位页；新增表不会影响已有模块读取。