### PR TITLE
feat: add valuation tools MVP

### DIFF
--- a/app/valuations/actions.ts
+++ b/app/valuations/actions.ts
@@ -1,0 +1,134 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { companies, valuations } from "@/db/schema";
+import {
+  calculateValuation,
+  type ValuationScenarioInput
+} from "@/lib/valuations/calculations";
+import { getTemplate, scenarios, type ScenarioName, type ValuationTemplateType } from "@/lib/valuations/constants";
+
+const valuationSchema = z.object({
+  companyId: z.string().trim().optional(),
+  templateType: z.enum(["financial", "cyclical", "consumer", "manufacturing"]),
+  title: z.string().trim().min(1, "请填写估值标题。"),
+  valuationDate: z.string().trim().min(1, "请选择估值日期。"),
+  currentPrice: z.coerce.number().nonnegative("当前价格不能为负。"),
+  sharesOutstanding: z.coerce.number().positive("总股本必须大于 0。"),
+  userNotes: z.string().trim().default("")
+});
+
+const scenarioSchema = z.object({
+  basisAmount: z.coerce.number().nonnegative(),
+  growthRate: z.coerce.number().default(0),
+  valuationMultiple: z.coerce.number().nonnegative(),
+  discountRate: z.coerce.number().positive().default(10),
+  terminalGrowthRate: z.coerce.number().default(2),
+  dividendYield: z.coerce.number().nonnegative().default(0),
+  notes: z.string().trim().default("")
+});
+
+function now() {
+  return new Date().toISOString();
+}
+
+function statusRedirect(status: string, message: string): never {
+  redirect(`/valuations?status=${encodeURIComponent(status)}&message=${encodeURIComponent(message)}`);
+}
+
+export async function saveValuation(formData: FormData) {
+  const parsed = valuationSchema.safeParse({
+    companyId: String(formData.get("companyId") ?? "").trim() || undefined,
+    templateType: formData.get("templateType"),
+    title: formData.get("title"),
+    valuationDate: formData.get("valuationDate"),
+    currentPrice: formData.get("currentPrice"),
+    sharesOutstanding: formData.get("sharesOutstanding"),
+    userNotes: formData.get("userNotes")
+  });
+
+  if (!parsed.success) {
+    statusRedirect("error", parsed.error.issues[0]?.message ?? "估值表单校验失败。");
+  }
+
+  const scenarioInputs = scenarios.map((scenario) =>
+    parseScenario(formData, scenario.value)
+  );
+  const invalidScenario = scenarioInputs.find((scenario) => scenario.basisAmount <= 0);
+
+  if (invalidScenario) {
+    statusRedirect("error", "三个情景都需要填写有效的估值起点。");
+  }
+
+  const result = calculateValuation({
+    templateType: parsed.data.templateType,
+    currentPrice: parsed.data.currentPrice,
+    sharesOutstanding: parsed.data.sharesOutstanding,
+    scenarios: scenarioInputs
+  });
+  const template = getTemplate(parsed.data.templateType);
+  const timestamp = now();
+
+  await db.insert(valuations).values({
+    id: crypto.randomUUID(),
+    companyId: parsed.data.companyId ?? null,
+    templateType: parsed.data.templateType,
+    title: parsed.data.title || `${template.label}估值`,
+    valuationDate: parsed.data.valuationDate,
+    currentPrice: Math.round(parsed.data.currentPrice * 100),
+    sharesOutstanding: Math.round(parsed.data.sharesOutstanding * 100),
+    currency: "CNY",
+    scenarioBearJson: JSON.stringify(scenarioInputs.find((scenario) => scenario.name === "bear")),
+    scenarioBaseJson: JSON.stringify(scenarioInputs.find((scenario) => scenario.name === "base")),
+    scenarioBullJson: JSON.stringify(scenarioInputs.find((scenario) => scenario.name === "bull")),
+    resultJson: JSON.stringify(result),
+    userNotes: parsed.data.userNotes,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  if (parsed.data.companyId) {
+    await db
+      .update(companies)
+      .set({
+        valuationStatus: "scenario",
+        updatedAt: timestamp
+      })
+      .where(eq(companies.id, parsed.data.companyId));
+  }
+
+  revalidatePath("/valuations");
+  revalidatePath("/watchlist");
+  statusRedirect("success", "估值记录已保存。");
+}
+
+function parseScenario(formData: FormData, name: ScenarioName): ValuationScenarioInput {
+  const parsed = scenarioSchema.safeParse({
+    basisAmount: formData.get(`${name}.basisAmount`),
+    growthRate: formData.get(`${name}.growthRate`),
+    valuationMultiple: formData.get(`${name}.valuationMultiple`),
+    discountRate: formData.get(`${name}.discountRate`),
+    terminalGrowthRate: formData.get(`${name}.terminalGrowthRate`),
+    dividendYield: formData.get(`${name}.dividendYield`),
+    notes: formData.get(`${name}.notes`)
+  });
+
+  if (!parsed.success) {
+    statusRedirect("error", `${name} 情景参数校验失败。`);
+  }
+
+  return {
+    name,
+    basisAmount: parsed.data.basisAmount,
+    growthRate: parsed.data.growthRate / 100,
+    valuationMultiple: parsed.data.valuationMultiple,
+    discountRate: parsed.data.discountRate / 100,
+    terminalGrowthRate: parsed.data.terminalGrowthRate / 100,
+    dividendYield: parsed.data.dividendYield / 100,
+    notes: parsed.data.notes
+  };
+}

--- a/app/valuations/page.tsx
+++ b/app/valuations/page.tsx
@@ -1,11 +1,423 @@
-import { PlaceholderPage } from "@/components/ui/placeholder-page";
+import Link from "next/link";
+import { AlertCircle, Bot, Calculator, CheckCircle2, ShieldAlert, Sigma } from "lucide-react";
+import { PendingButton } from "@/components/ui/pending-button";
+import { SectionHeader } from "@/components/ui/section-header";
+import type { companies, valuations } from "@/db/schema";
+import type { ValuationResult, ValuationScenarioInput } from "@/lib/valuations/calculations";
+import {
+  getTemplate,
+  labelFor,
+  scenarios,
+  valuationTemplates,
+  type ValuationTemplateType
+} from "@/lib/valuations/constants";
+import { getValuationsPageData } from "@/lib/valuations/queries";
+import { saveValuation } from "./actions";
 
-export default function ValuationsPage() {
+type ValuationsPageProps = {
+  searchParams?: Promise<{
+    status?: string;
+    message?: string;
+  }>;
+};
+
+type Company = typeof companies.$inferSelect;
+type Valuation = typeof valuations.$inferSelect;
+
+const defaultScenarioValues = {
+  bear: { basisAmount: "", growthRate: "0", valuationMultiple: "", discountRate: "12", terminalGrowthRate: "2", dividendYield: "0" },
+  base: { basisAmount: "", growthRate: "5", valuationMultiple: "", discountRate: "10", terminalGrowthRate: "2.5", dividendYield: "0" },
+  bull: { basisAmount: "", growthRate: "10", valuationMultiple: "", discountRate: "9", terminalGrowthRate: "3", dividendYield: "0" }
+};
+
+export default async function ValuationsPage({ searchParams }: ValuationsPageProps) {
+  const paramsPromise: Promise<{ status?: string; message?: string }> = searchParams ?? Promise.resolve({});
+  const [params, data] = await Promise.all([paramsPromise, getValuationsPageData()]);
+
   return (
-    <PlaceholderPage
-      title="估值工具"
-      description="第一版覆盖金融、周期、消费、制造四类模板，并提供通用 DCF 和安全边际计算。"
-      items={["金融股模板", "周期股模板", "消费股模板", "制造业模板", "反向 DCF", "安全边际"]}
-    />
+    <main className="space-y-8">
+      <section className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <SectionHeader
+            title="估值工具"
+            description="用四类 A 股模板完成三情景估值：只输出区间、假设、安全边际和风险提醒，不输出买入或卖出建议。"
+          />
+          <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
+            <Metric label="模板" value={valuationTemplates.length} />
+            <Metric label="公司" value={data.companies.length} />
+            <Metric label="估值" value={data.valuations.length} />
+          </div>
+        </div>
+      </section>
+
+      {params.message ? (
+        <StatusBanner status={params.status === "success" ? "success" : "error"} message={params.message} />
+      ) : null}
+
+      <section className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <section className="rounded-lg border border-border bg-card p-6">
+          <div className="flex items-center gap-2">
+            <Calculator className="h-5 w-5 text-primary" aria-hidden />
+            <h2 className="text-xl font-semibold">创建估值</h2>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            数量单位建议统一：当前价格为元/股，总股本为亿股；利润、自由现金流为亿元。这样计算出的每股估值约为元/股。
+          </p>
+          <div className="mt-5 space-y-5">
+            {valuationTemplates.map((template) => (
+              <ValuationForm
+                key={template.value}
+                templateType={template.value}
+                companies={data.companies}
+              />
+            ))}
+          </div>
+        </section>
+
+        <RecentValuations valuations={data.valuations} />
+      </section>
+    </main>
   );
+}
+
+function ValuationForm({
+  templateType,
+  companies
+}: {
+  templateType: ValuationTemplateType;
+  companies: Company[];
+}) {
+  const template = getTemplate(templateType);
+
+  return (
+    <details className="rounded-lg border border-border bg-background p-4" open={templateType === "financial"}>
+      <summary className="cursor-pointer text-sm font-semibold">
+        {template.label} <span className="text-muted-foreground">/ {template.method}</span>
+      </summary>
+      <p className="mt-3 text-sm leading-6 text-muted-foreground">{template.focus}</p>
+
+      <form action={saveValuation} className="mt-4 space-y-5">
+        <input type="hidden" name="templateType" value={templateType} />
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block">
+            <span className="text-sm font-semibold">关联公司</span>
+            <select
+              name="companyId"
+              className="mt-2 w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none transition focus:border-primary"
+            >
+              <option value="">不关联公司</option>
+              {companies.map((company) => (
+                <option key={company.id} value={company.id}>
+                  {company.stockName}（{company.stockCode}）
+                </option>
+              ))}
+            </select>
+          </label>
+          <Field label="估值标题" name="title" defaultValue={`${template.label}估值`} />
+          <Field label="估值日期" name="valuationDate" type="date" defaultValue={new Date().toISOString().slice(0, 10)} />
+          <Field label="当前价格（元/股）" name="currentPrice" type="number" step="0.01" />
+          <Field label="总股本（亿股）" name="sharesOutstanding" type="number" step="0.0001" />
+        </div>
+
+        <div className="grid gap-4">
+          {scenarios.map((scenario) => (
+            <ScenarioFields
+              key={scenario.value}
+              scenario={scenario.value}
+              label={scenario.label}
+              templateType={templateType}
+            />
+          ))}
+        </div>
+
+        <TextArea label="备注和资料来源" name="userNotes" placeholder="写下数据来源、关键假设、还没确认的问题。不要把模型输出当成事实。" />
+
+        <PendingButton
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+          pendingChildren="计算并保存中..."
+        >
+          <CheckCircle2 className="h-4 w-4" aria-hidden />
+          计算并保存估值
+        </PendingButton>
+      </form>
+    </details>
+  );
+}
+
+function ScenarioFields({
+  scenario,
+  label,
+  templateType
+}: {
+  scenario: "bear" | "base" | "bull";
+  label: string;
+  templateType: ValuationTemplateType;
+}) {
+  const template = getTemplate(templateType);
+  const defaults = defaultScenarioValues[scenario];
+  const isFinancial = templateType === "financial";
+  const isManufacturing = templateType === "manufacturing";
+
+  return (
+    <fieldset className="rounded-lg border border-border bg-card p-4">
+      <legend className="px-1 text-sm font-semibold">{label}情景</legend>
+      <div className="grid gap-4 md:grid-cols-3">
+        <Field
+          label={template.basisLabel}
+          name={`${scenario}.basisAmount`}
+          type="number"
+          step="0.0001"
+          placeholder={template.basisHint}
+          defaultValue={defaults.basisAmount}
+        />
+        <Field
+          label={template.growthLabel}
+          name={`${scenario}.growthRate`}
+          type="number"
+          step="0.1"
+          defaultValue={isFinancial ? "0" : defaults.growthRate}
+          suffix="%"
+        />
+        <Field
+          label={template.multipleLabel}
+          name={`${scenario}.valuationMultiple`}
+          type="number"
+          step="0.01"
+          defaultValue={defaults.valuationMultiple}
+        />
+        <Field
+          label="折现率"
+          name={`${scenario}.discountRate`}
+          type="number"
+          step="0.1"
+          defaultValue={defaults.discountRate}
+          suffix="%"
+          disabled={!isManufacturing}
+        />
+        <Field
+          label="永续增长率"
+          name={`${scenario}.terminalGrowthRate`}
+          type="number"
+          step="0.1"
+          defaultValue={defaults.terminalGrowthRate}
+          suffix="%"
+          disabled={!isManufacturing}
+        />
+        <Field
+          label="预期股息率"
+          name={`${scenario}.dividendYield`}
+          type="number"
+          step="0.1"
+          defaultValue={defaults.dividendYield}
+          suffix="%"
+        />
+      </div>
+      <TextArea label="情景说明" name={`${scenario}.notes`} placeholder="这个情景成立需要哪些条件？哪些变量最敏感？" />
+    </fieldset>
+  );
+}
+
+function RecentValuations({
+  valuations
+}: {
+  valuations: Array<{ valuation: Valuation; company: Company | null }>;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <Sigma className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">最近估值</h2>
+      </div>
+      <div className="mt-5 space-y-4">
+        {valuations.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-background p-6 text-sm leading-6 text-muted-foreground">
+            还没有估值记录。先选择一个模板，录入三情景参数并保存。
+          </div>
+        ) : (
+          valuations.map(({ valuation, company }) => (
+            <ValuationCard key={valuation.id} valuation={valuation} company={company} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ValuationCard({ valuation, company }: { valuation: Valuation; company: Company | null }) {
+  const result = parseJson<ValuationResult>(valuation.resultJson);
+  const bear = parseJson<ValuationScenarioInput>(valuation.scenarioBearJson);
+  const base = parseJson<ValuationScenarioInput>(valuation.scenarioBaseJson);
+  const bull = parseJson<ValuationScenarioInput>(valuation.scenarioBullJson);
+  const template = getTemplate(valuation.templateType);
+  const currentPrice = valuation.currentPrice / 100;
+  const aiDraft = `请作为耐心的价值投资导师，用通俗语言解释这份 A 股估值。不要给买入或卖出建议，只解释估值方法、关键参数、安全边际和主要风险。公司=${company ? `${company.stockName}（${company.stockCode}）` : "未关联"}；模板=${template.label}；当前价格=${formatNumber(currentPrice)}；估值区间=${formatNumber(result.lowValuePerShare)}-${formatNumber(result.highValuePerShare)}；中性情景=${formatNumber(result.baseValuePerShare)}；安全边际=${formatPercent(result.baseMarginOfSafety)}；悲观假设=${bear.notes || "未填写"}；中性假设=${base.notes || "未填写"}；乐观假设=${bull.notes || "未填写"}。`;
+  const opponentDraft = `请作为投资委员会反方委员，质疑这份 A 股估值。不要给买入或卖出建议，请重点找乐观假设、模型误用、风险遗漏和需要补证据的地方。公司=${company ? `${company.stockName}（${company.stockCode}）` : "未关联"}；模板=${template.label}；当前价格=${formatNumber(currentPrice)}；估值区间=${formatNumber(result.lowValuePerShare)}-${formatNumber(result.highValuePerShare)}；中性安全边际=${formatPercent(result.baseMarginOfSafety)}；风险提示=${result.riskFlags.join("；") || "无"}。`;
+
+  return (
+    <article className="rounded-lg border border-border bg-background p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="text-sm font-semibold">{valuation.title}</div>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {company ? `${company.stockName}（${company.stockCode}）` : "未关联公司"} / {labelFor(valuationTemplates, valuation.templateType)} / {valuation.valuationDate}
+          </p>
+        </div>
+        <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+          {template.method}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        <InfoBlock title="估值区间" value={`${formatNumber(result.lowValuePerShare)} - ${formatNumber(result.highValuePerShare)} 元/股`} />
+        <InfoBlock title="中性情景" value={`${formatNumber(result.baseValuePerShare)} 元/股`} />
+        <InfoBlock title="安全边际" value={formatPercent(result.baseMarginOfSafety)} />
+      </div>
+
+      {result.riskFlags.length > 0 ? (
+        <div className="mt-4 rounded-md border border-border bg-card p-3">
+          <div className="text-xs font-semibold text-primary">风险提醒</div>
+          <ul className="mt-2 space-y-1 text-sm leading-6 text-muted-foreground">
+            {result.riskFlags.map((flag) => (
+              <li key={flag}>{flag}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Link
+          href={`/mentor?role=mentor&draft=${encodeURIComponent(aiDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <Bot className="h-4 w-4" aria-hidden />
+          让导师解释
+        </Link>
+        <Link
+          href={`/mentor?role=opponent&draft=${encodeURIComponent(opponentDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <ShieldAlert className="h-4 w-4" aria-hidden />
+          反方质询
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function Field({
+  label,
+  name,
+  type = "text",
+  step,
+  defaultValue = "",
+  placeholder,
+  suffix,
+  disabled = false
+}: {
+  label: string;
+  name: string;
+  type?: string;
+  step?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  suffix?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <div className="mt-2 flex rounded-md border border-border bg-background focus-within:border-primary">
+        <input
+          name={name}
+          type={type}
+          step={step}
+          defaultValue={defaultValue}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="min-w-0 flex-1 rounded-md bg-transparent px-3 py-2 text-sm outline-none disabled:text-muted-foreground"
+        />
+        {suffix ? <span className="border-l border-border px-3 py-2 text-sm text-muted-foreground">{suffix}</span> : null}
+      </div>
+    </label>
+  );
+}
+
+function TextArea({
+  label,
+  name,
+  defaultValue = "",
+  placeholder
+}: {
+  label: string;
+  name: string;
+  defaultValue?: string;
+  placeholder: string;
+}) {
+  return (
+    <label className="mt-4 block">
+      <span className="text-sm font-semibold">{label}</span>
+      <textarea
+        name={name}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        rows={3}
+        className="mt-2 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm leading-6 outline-none transition focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function StatusBanner({ status, message }: { status: "success" | "error"; message: string }) {
+  const Icon = status === "success" ? CheckCircle2 : AlertCircle;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <Icon className="mt-0.5 h-5 w-5 text-primary" aria-hidden />
+        <p className="text-sm leading-6">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function InfoBlock({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="text-xs font-semibold text-primary">{title}</div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{value}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="min-w-20 rounded-md bg-card px-4 py-3">
+      <div className="text-xl font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+function parseJson<T>(value: string): T {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
+function formatNumber(value: number) {
+  if (!Number.isFinite(value)) {
+    return "0.00";
+  }
+
+  return value.toFixed(2);
+}
+
+function formatPercent(value: number) {
+  if (!Number.isFinite(value)) {
+    return "0.0%";
+  }
+
+  return `${(value * 100).toFixed(1)}%`;
 }

--- a/src/db/migrations/0005_lush_bruce_banner.sql
+++ b/src/db/migrations/0005_lush_bruce_banner.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `valuations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`company_id` text,
+	`template_type` text NOT NULL,
+	`title` text NOT NULL,
+	`valuation_date` text NOT NULL,
+	`current_price` integer DEFAULT 0 NOT NULL,
+	`shares_outstanding` integer DEFAULT 0 NOT NULL,
+	`currency` text DEFAULT 'CNY' NOT NULL,
+	`scenario_bear_json` text DEFAULT '{}' NOT NULL,
+	`scenario_base_json` text DEFAULT '{}' NOT NULL,
+	`scenario_bull_json` text DEFAULT '{}' NOT NULL,
+	`result_json` text DEFAULT '{}' NOT NULL,
+	`user_notes` text DEFAULT '' NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE set null
+);

--- a/src/db/migrations/meta/0005_snapshot.json
+++ b/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1066 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d2f3a0f6-ef72-42cd-8364-02aa06bf9dbb",
+  "prevId": "d49ecdf9-4b32-450b-985c-ebedeeb3d801",
+  "tables": {
+    "ai_conversations": {
+      "name": "ai_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_conversations_provider_id_model_providers_id_fk": {
+          "name": "ai_conversations_provider_id_model_providers_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_messages": {
+      "name": "ai_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_messages_conversation_id_ai_conversations_id_fk": {
+          "name": "ai_messages_conversation_id_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checklist_runs": {
+      "name": "checklist_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_type": {
+          "name": "checklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "final_judgment": {
+          "name": "final_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_runs_company_id_companies_id_fk": {
+          "name": "checklist_runs_company_id_companies_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "checklist_runs_principle_id_investment_principles_id_fk": {
+          "name": "checklist_runs_principle_id_investment_principles_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_code": {
+          "name": "stock_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_name": {
+          "name": "stock_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "watch_status": {
+          "name": "watch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'watching'"
+        },
+        "valuation_status": {
+          "name": "valuation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "in_circle": {
+          "name": "in_circle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "thesis": {
+          "name": "thesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "key_risks": {
+          "name": "key_risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decisions": {
+      "name": "decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checklist_run_id": {
+          "name": "checklist_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_type": {
+          "name": "decision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "final_user_judgment": {
+          "name": "final_user_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_assumptions": {
+          "name": "key_assumptions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risks": {
+          "name": "risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "opponent_summary": {
+          "name": "opponent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "decision_date": {
+          "name": "decision_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "decisions_company_id_companies_id_fk": {
+          "name": "decisions_company_id_companies_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_checklist_run_id_checklist_runs_id_fk": {
+          "name": "decisions_checklist_run_id_checklist_runs_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "checklist_runs",
+          "columnsFrom": [
+            "checklist_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_principle_id_investment_principles_id_fk": {
+          "name": "decisions_principle_id_investment_principles_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "investment_principles": {
+      "name": "investment_principles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'我的 A 股价值投资原则'"
+        },
+        "circle_of_competence": {
+          "name": "circle_of_competence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "excluded_industries": {
+          "name": "excluded_industries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_financial_quality": {
+          "name": "minimum_financial_quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_margin_of_safety": {
+          "name": "minimum_margin_of_safety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_rules": {
+          "name": "position_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "buy_rules": {
+          "name": "buy_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sell_rules": {
+          "name": "sell_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_nothing_rules": {
+          "name": "do_nothing_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risk_rules": {
+          "name": "risk_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_nodes": {
+      "name": "knowledge_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_configs_provider_id_model_providers_id_fk": {
+          "name": "model_configs_provider_id_model_providers_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_providers": {
+      "name": "model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_openai_compatible": {
+          "name": "is_openai_compatible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_insecure_tls": {
+          "name": "allow_insecure_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_name": {
+          "name": "default_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_temperature": {
+          "name": "default_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "max_context_tokens": {
+          "name": "max_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8000
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_tested'"
+        },
+        "last_test_message": {
+          "name": "last_test_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "valuations": {
+      "name": "valuations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_type": {
+          "name": "template_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "valuation_date": {
+          "name": "valuation_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shares_outstanding": {
+          "name": "shares_outstanding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CNY'"
+        },
+        "scenario_bear_json": {
+          "name": "scenario_bear_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_base_json": {
+          "name": "scenario_base_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_bull_json": {
+          "name": "scenario_bull_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "valuations_company_id_companies_id_fk": {
+          "name": "valuations_company_id_companies_id_fk",
+          "tableFrom": "valuations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777705339999,
       "tag": "0004_stale_crystal",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1777705793377,
+      "tag": "0005_lush_bruce_banner",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -128,3 +128,21 @@ export const decisions = sqliteTable("decisions", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull()
 });
+
+export const valuations = sqliteTable("valuations", {
+  id: text("id").primaryKey(),
+  companyId: text("company_id").references(() => companies.id, { onDelete: "set null" }),
+  templateType: text("template_type").notNull(),
+  title: text("title").notNull(),
+  valuationDate: text("valuation_date").notNull(),
+  currentPrice: integer("current_price").notNull().default(0),
+  sharesOutstanding: integer("shares_outstanding").notNull().default(0),
+  currency: text("currency").notNull().default("CNY"),
+  scenarioBearJson: text("scenario_bear_json").notNull().default("{}"),
+  scenarioBaseJson: text("scenario_base_json").notNull().default("{}"),
+  scenarioBullJson: text("scenario_bull_json").notNull().default("{}"),
+  resultJson: text("result_json").notNull().default("{}"),
+  userNotes: text("user_notes").notNull().default(""),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});

--- a/src/lib/valuations/calculations.ts
+++ b/src/lib/valuations/calculations.ts
@@ -1,0 +1,177 @@
+import type { ScenarioName, ValuationTemplateType } from "@/lib/valuations/constants";
+
+export type ValuationScenarioInput = {
+  name: ScenarioName;
+  basisAmount: number;
+  growthRate: number;
+  valuationMultiple: number;
+  discountRate: number;
+  terminalGrowthRate: number;
+  dividendYield: number;
+  notes: string;
+};
+
+export type ScenarioResult = {
+  name: ScenarioName;
+  valuePerShare: number;
+  equityValue: number;
+  marginOfSafety: number;
+  impliedUpside: number;
+};
+
+export type ValuationResult = {
+  lowValuePerShare: number;
+  baseValuePerShare: number;
+  highValuePerShare: number;
+  baseMarginOfSafety: number;
+  baseImpliedUpside: number;
+  scenarioResults: ScenarioResult[];
+  riskFlags: string[];
+};
+
+export function calculateValuation({
+  templateType,
+  currentPrice,
+  sharesOutstanding,
+  scenarios
+}: {
+  templateType: ValuationTemplateType;
+  currentPrice: number;
+  sharesOutstanding: number;
+  scenarios: ValuationScenarioInput[];
+}): ValuationResult {
+  const scenarioResults = scenarios.map((scenario) =>
+    calculateScenario({ templateType, currentPrice, sharesOutstanding, scenario })
+  );
+  const sortedValues = scenarioResults.map((scenario) => scenario.valuePerShare).sort((a, b) => a - b);
+  const base = scenarioResults.find((scenario) => scenario.name === "base") ?? scenarioResults[1] ?? scenarioResults[0];
+
+  return {
+    lowValuePerShare: sortedValues[0] ?? 0,
+    baseValuePerShare: base?.valuePerShare ?? 0,
+    highValuePerShare: sortedValues[sortedValues.length - 1] ?? 0,
+    baseMarginOfSafety: base?.marginOfSafety ?? 0,
+    baseImpliedUpside: base?.impliedUpside ?? 0,
+    scenarioResults,
+    riskFlags: buildRiskFlags({ templateType, currentPrice, sharesOutstanding, scenarios, baseValue: base?.valuePerShare ?? 0 })
+  };
+}
+
+function calculateScenario({
+  templateType,
+  currentPrice,
+  sharesOutstanding,
+  scenario
+}: {
+  templateType: ValuationTemplateType;
+  currentPrice: number;
+  sharesOutstanding: number;
+  scenario: ValuationScenarioInput;
+}): ScenarioResult {
+  let valuePerShare = 0;
+
+  if (templateType === "financial") {
+    valuePerShare = scenario.basisAmount * scenario.valuationMultiple;
+  }
+
+  if (templateType === "cyclical") {
+    valuePerShare = sharesOutstanding > 0 ? (scenario.basisAmount * scenario.valuationMultiple) / sharesOutstanding : 0;
+  }
+
+  if (templateType === "consumer") {
+    const normalizedProfit = scenario.basisAmount * Math.pow(1 + scenario.growthRate, 3);
+    valuePerShare = sharesOutstanding > 0 ? (normalizedProfit * scenario.valuationMultiple) / sharesOutstanding : 0;
+  }
+
+  if (templateType === "manufacturing") {
+    const dcfValue = calculateDcfPerShare({ scenario, sharesOutstanding });
+    const peCrossCheck =
+      sharesOutstanding > 0 && scenario.valuationMultiple > 0
+        ? (scenario.basisAmount * Math.pow(1 + scenario.growthRate, 3) * scenario.valuationMultiple) / sharesOutstanding
+        : 0;
+    valuePerShare = peCrossCheck > 0 ? (dcfValue + peCrossCheck) / 2 : dcfValue;
+  }
+
+  const equityValue = valuePerShare * sharesOutstanding;
+  const marginOfSafety = valuePerShare > 0 ? (valuePerShare - currentPrice) / valuePerShare : 0;
+  const impliedUpside = currentPrice > 0 ? (valuePerShare - currentPrice) / currentPrice : 0;
+
+  return {
+    name: scenario.name,
+    valuePerShare: round(valuePerShare),
+    equityValue: round(equityValue),
+    marginOfSafety: round(marginOfSafety),
+    impliedUpside: round(impliedUpside)
+  };
+}
+
+function calculateDcfPerShare({
+  scenario,
+  sharesOutstanding
+}: {
+  scenario: ValuationScenarioInput;
+  sharesOutstanding: number;
+}) {
+  const discountRate = Math.max(scenario.discountRate, 0.01);
+  const terminalGrowthRate = Math.min(scenario.terminalGrowthRate, discountRate - 0.005);
+  let presentValue = 0;
+  let fcf = scenario.basisAmount;
+
+  for (let year = 1; year <= 5; year += 1) {
+    fcf *= 1 + scenario.growthRate;
+    presentValue += fcf / Math.pow(1 + discountRate, year);
+  }
+
+  const terminalValue = (fcf * (1 + terminalGrowthRate)) / (discountRate - terminalGrowthRate);
+  const presentTerminalValue = terminalValue / Math.pow(1 + discountRate, 5);
+  const equityValue = presentValue + presentTerminalValue;
+
+  return sharesOutstanding > 0 ? equityValue / sharesOutstanding : 0;
+}
+
+function buildRiskFlags({
+  templateType,
+  currentPrice,
+  sharesOutstanding,
+  scenarios,
+  baseValue
+}: {
+  templateType: ValuationTemplateType;
+  currentPrice: number;
+  sharesOutstanding: number;
+  scenarios: ValuationScenarioInput[];
+  baseValue: number;
+}) {
+  const flags: string[] = [];
+  const baseScenario = scenarios.find((scenario) => scenario.name === "base");
+
+  if (sharesOutstanding <= 0) {
+    flags.push("总股本必须大于 0，否则每股估值不可靠。");
+  }
+
+  if (currentPrice > 0 && baseValue > 0 && currentPrice > baseValue) {
+    flags.push("当前价格高于中性情景估值，安全边际为负。");
+  }
+
+  if (baseScenario && baseScenario.growthRate > 0.2) {
+    flags.push("中性情景增长假设较高，需要反复验证增长来源。");
+  }
+
+  if (templateType === "manufacturing" && baseScenario && baseScenario.terminalGrowthRate >= baseScenario.discountRate - 0.01) {
+    flags.push("永续增长率接近折现率，DCF 结果会非常敏感。");
+  }
+
+  if (templateType === "cyclical") {
+    flags.push("周期股估值要避免使用景气顶部利润作为中枢利润。");
+  }
+
+  if (templateType === "financial") {
+    flags.push("金融股 PB 估值必须结合资产质量、拨备和 ROE 可持续性。");
+  }
+
+  return flags;
+}
+
+function round(value: number) {
+  return Math.round(value * 10000) / 10000;
+}

--- a/src/lib/valuations/constants.ts
+++ b/src/lib/valuations/constants.ts
@@ -1,0 +1,60 @@
+export const valuationTemplates = [
+  {
+    value: "financial",
+    label: "金融股模板",
+    method: "PB-ROE / 股息辅助",
+    basisLabel: "每股净资产",
+    basisHint: "元/股，例如银行常用每股净资产作为估值起点。",
+    multipleLabel: "PB 倍数",
+    growthLabel: "ROE 或利润变化",
+    focus: "关注 ROE 可持续性、资产质量、不良率、拨备和资本充足。"
+  },
+  {
+    value: "cyclical",
+    label: "周期股模板",
+    method: "周期中枢利润 PE",
+    basisLabel: "中枢净利润",
+    basisHint: "亿元，尽量使用跨周期利润中枢，而不是景气顶部利润。",
+    multipleLabel: "中枢 PE 倍数",
+    growthLabel: "利润修正",
+    focus: "关注当前景气位置、商品价格、负债和资本开支。"
+  },
+  {
+    value: "consumer",
+    label: "消费股模板",
+    method: "利润增长后的 PE 情景",
+    basisLabel: "当前净利润",
+    basisHint: "亿元，使用最近一年归母净利润或更保守的正常化利润。",
+    multipleLabel: "合理 PE 倍数",
+    growthLabel: "未来三年年化利润增长",
+    focus: "关注增长、ROE、现金流、渠道库存、提价能力和品牌强度。"
+  },
+  {
+    value: "manufacturing",
+    label: "制造业模板",
+    method: "五年简化 DCF + PE 交叉验证",
+    basisLabel: "自由现金流起点",
+    basisHint: "亿元，尽量使用可持续自由现金流，而不是单年高点。",
+    multipleLabel: "备用 PE 倍数",
+    growthLabel: "未来五年 FCF 增长",
+    focus: "关注资本开支、研发、存货、应收、客户集中和竞争格局。"
+  }
+] as const;
+
+export type ValuationTemplateType = (typeof valuationTemplates)[number]["value"];
+
+export type ScenarioName = "bear" | "base" | "bull";
+
+export const scenarios = [
+  { value: "bear", label: "悲观" },
+  { value: "base", label: "中性" },
+  { value: "bull", label: "乐观" }
+] as const;
+
+export function labelFor<T extends { value: string; label: string }>(options: readonly T[], value: string) {
+  return options.find((option) => option.value === value)?.label ?? value;
+}
+
+export function getTemplate(type: string) {
+  return valuationTemplates.find((template) => template.value === type) ?? valuationTemplates[0];
+}

--- a/src/lib/valuations/queries.ts
+++ b/src/lib/valuations/queries.ts
@@ -1,0 +1,23 @@
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { companies, valuations } from "@/db/schema";
+
+export async function getValuationsPageData() {
+  const [companyRows, valuationRows] = await Promise.all([
+    db.select().from(companies).orderBy(desc(companies.updatedAt)),
+    db
+      .select({
+        valuation: valuations,
+        company: companies
+      })
+      .from(valuations)
+      .leftJoin(companies, eq(valuations.companyId, companies.id))
+      .orderBy(desc(valuations.createdAt))
+      .limit(8)
+  ]);
+
+  return {
+    companies: companyRows,
+    valuations: valuationRows
+  };
+}


### PR DESCRIPTION
## 关联 Issue\n\nCloses #13\n\n## 改动摘要\n\n- 将估值工具占位页升级为可用的四类 A 股估值工具。\n- 支持金融、周期、消费、制造四类模板。\n- 每个模板支持悲观、中性、乐观三情景输入。\n- 输出每股估值区间、中性情景、安全边际和风险提醒。\n- 支持保存估值记录，并将关联公司的估值状态更新为三情景完成。\n- 最近估值提供 AI 导师解释和反方质询入口，不输出买卖建议。\n\n## 主要文件\n\n- app/valuations/page.tsx\n- app/valuations/actions.ts\n- src/lib/valuations/constants.ts\n- src/lib/valuations/calculations.ts\n- src/lib/valuations/queries.ts\n- src/db/schema.ts\n- src/db/migrations/0005_lush_bruce_banner.sql\n\n## 验证\n\n- [x] npm run db:generate\n- [x] npm run db:migrate\n- [x] npm run typecheck\n- [x] npm run build\n- [x] 重启 next dev 后验证 /valuations 返回 200\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n\n## 截图 / 说明\n\n/valuations 页面包含创建估值和最近估值两个区域。第一版使用统一表单承载模板差异：金融 PB，周期中枢利润 PE，消费利润增长 PE，制造简化 DCF + PE 交叉验证。\n\n## 数据库迁移\n\n新增 valuations 表，用于保存公司、模板、三情景输入、估值结果和备注。新增表不影响已有模块。\n\n## 风险\n\n- 第一版不接入实时行情，当前价格和财务数据由用户手动录入。\n- 第一版不做复杂敏感性图表，风险提示以文本为主。\n\n## 回退方案\n\n回退本 PR 可恢复估值工具占位页；新增 valuations 表不会影响已有模块读取。