### PR TITLE
feat: add reviews MVP

### DIFF
--- a/app/reviews/actions.ts
+++ b/app/reviews/actions.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { decisions, reviews } from "@/db/schema";
+
+const reviewSchema = z.object({
+  decisionId: z.string().trim().optional(),
+  reviewType: z.enum(["post_decision", "quarterly", "annual", "mistake"]),
+  reviewDate: z.string().trim().min(1, "请选择复盘日期。"),
+  whatHappened: z.string().trim().min(1, "请填写实际发生了什么。"),
+  assumptionsValidated: z.string().trim().default(""),
+  assumptionsFailed: z.string().trim().default(""),
+  lessons: z.string().trim().min(1, "请填写经验教训。"),
+  principleChangesNeeded: z.string().trim().default("")
+});
+
+function now() {
+  return new Date().toISOString();
+}
+
+function statusRedirect(status: string, message: string): never {
+  redirect(`/reviews?status=${encodeURIComponent(status)}&message=${encodeURIComponent(message)}`);
+}
+
+export async function saveReview(formData: FormData) {
+  const parsed = reviewSchema.safeParse({
+    decisionId: String(formData.get("decisionId") ?? "").trim() || undefined,
+    reviewType: formData.get("reviewType"),
+    reviewDate: formData.get("reviewDate"),
+    whatHappened: formData.get("whatHappened"),
+    assumptionsValidated: formData.get("assumptionsValidated"),
+    assumptionsFailed: formData.get("assumptionsFailed"),
+    lessons: formData.get("lessons"),
+    principleChangesNeeded: formData.get("principleChangesNeeded")
+  });
+
+  if (!parsed.success) {
+    statusRedirect("error", parsed.error.issues[0]?.message ?? "复盘记录校验失败。");
+  }
+
+  const [decision] = parsed.data.decisionId
+    ? await db.select().from(decisions).where(eq(decisions.id, parsed.data.decisionId)).limit(1)
+    : [];
+  const timestamp = now();
+
+  await db.insert(reviews).values({
+    id: crypto.randomUUID(),
+    decisionId: parsed.data.decisionId ?? null,
+    companyId: decision?.companyId ?? null,
+    reviewType: parsed.data.reviewType,
+    reviewDate: parsed.data.reviewDate,
+    whatHappened: parsed.data.whatHappened,
+    assumptionsValidated: parsed.data.assumptionsValidated,
+    assumptionsFailed: parsed.data.assumptionsFailed,
+    lessons: parsed.data.lessons,
+    principleChangesNeeded: parsed.data.principleChangesNeeded,
+    aiSummary: "",
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  revalidatePath("/reviews");
+  statusRedirect("success", "复盘记录已保存。");
+}

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -1,11 +1,272 @@
-import { PlaceholderPage } from "@/components/ui/placeholder-page";
+import Link from "next/link";
+import { AlertCircle, Bot, CheckCircle2, History, RotateCcw, ShieldAlert } from "lucide-react";
+import { PendingButton } from "@/components/ui/pending-button";
+import { SectionHeader } from "@/components/ui/section-header";
+import type { companies, decisions, reviews } from "@/db/schema";
+import { labelFor, reviewTypes } from "@/lib/reviews/constants";
+import { getReviewsPageData } from "@/lib/reviews/queries";
+import { saveReview } from "./actions";
 
-export default function ReviewsPage() {
+type ReviewsPageProps = {
+  searchParams?: Promise<{
+    status?: string;
+    message?: string;
+  }>;
+};
+
+type Company = typeof companies.$inferSelect;
+type Decision = typeof decisions.$inferSelect;
+type Review = typeof reviews.$inferSelect;
+
+export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
+  const paramsPromise: Promise<{ status?: string; message?: string }> = searchParams ?? Promise.resolve({});
+  const [params, data] = await Promise.all([paramsPromise, getReviewsPageData()]);
+
   return (
-    <PlaceholderPage
-      title="复盘"
-      description="记录假设是否成立、错误类型、经验教训和原则修订建议。"
-      items={["单次决策复盘", "季度复盘", "年度复盘", "错误案例库"]}
-    />
+    <main className="space-y-8">
+      <section className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <SectionHeader
+            title="复盘"
+            description="把每次判断放回事实里验证：哪些假设成立，哪些失败，哪些原则需要收紧。AI 只帮助总结和追问，不替你判定对错。"
+          />
+          <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
+            <Metric label="决策" value={data.decisions.length} />
+            <Metric label="复盘" value={data.reviews.length} />
+            <Metric label="类型" value={reviewTypes.length} />
+          </div>
+        </div>
+      </section>
+
+      {params.message ? (
+        <StatusBanner status={params.status === "success" ? "success" : "error"} message={params.message} />
+      ) : null}
+
+      <section className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+        <ReviewForm decisions={data.decisions} />
+        <RecentReviews reviews={data.reviews} />
+      </section>
+    </main>
+  );
+}
+
+function ReviewForm({
+  decisions
+}: {
+  decisions: Array<{ decision: Decision; company: Company | null }>;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <RotateCcw className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">创建复盘</h2>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        复盘不是证明自己对错，而是把假设、证据和原则校准到下一次更清晰。
+      </p>
+
+      <form action={saveReview} className="mt-5 space-y-4">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block">
+            <span className="text-sm font-semibold">关联决策</span>
+            <select
+              name="decisionId"
+              className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+            >
+              <option value="">不关联决策</option>
+              {decisions.map(({ decision, company }) => (
+                <option key={decision.id} value={decision.id}>
+                  {company ? `${company.stockName}（${company.stockCode}）` : "未关联公司"} / {decision.decisionDate} / {decision.finalUserJudgment.slice(0, 24)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-semibold">复盘类型</span>
+            <select
+              name="reviewType"
+              defaultValue="post_decision"
+              className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+            >
+              {reviewTypes.map((type) => (
+                <option key={type.value} value={type.value}>
+                  {type.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Field label="复盘日期" name="reviewDate" type="date" defaultValue={new Date().toISOString().slice(0, 10)} />
+        </div>
+
+        <TextArea label="实际发生了什么" name="whatHappened" placeholder="价格、基本面、行业、财报或你的行为发生了什么变化？" />
+        <TextArea label="哪些假设成立" name="assumptionsValidated" placeholder="哪些判断被事实验证？证据是什么？" />
+        <TextArea label="哪些假设失败" name="assumptionsFailed" placeholder="哪些判断错了、漏了或过度乐观？" />
+        <TextArea label="经验教训" name="lessons" placeholder="下次遇到类似情况，应该提前检查什么？" />
+        <TextArea label="原则修订建议" name="principleChangesNeeded" placeholder="哪些投资原则需要新增、改写、收紧或删除？" />
+
+        <PendingButton
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+          pendingChildren="保存中..."
+        >
+          <CheckCircle2 className="h-4 w-4" aria-hidden />
+          保存复盘
+        </PendingButton>
+      </form>
+    </section>
+  );
+}
+
+function RecentReviews({
+  reviews
+}: {
+  reviews: Array<{ review: Review; decision: Decision | null; company: Company | null }>;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <History className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">最近复盘</h2>
+      </div>
+      <div className="mt-5 space-y-4">
+        {reviews.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-background p-6 text-sm leading-6 text-muted-foreground">
+            还没有复盘记录。完成一次决策后，可以回来验证你的假设。
+          </div>
+        ) : (
+          reviews.map(({ review, decision, company }) => (
+            <ReviewCard key={review.id} review={review} decision={decision} company={company} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ReviewCard({
+  review,
+  decision,
+  company
+}: {
+  review: Review;
+  decision: Decision | null;
+  company: Company | null;
+}) {
+  const mentorDraft = `请作为耐心的价值投资导师，帮我总结这次 A 股投资复盘，并提出后续学习和原则修订建议。不要给买入或卖出建议。公司=${company ? `${company.stockName}（${company.stockCode}）` : "未关联"}；原决策=${decision?.finalUserJudgment || "未关联"}；实际发生=${review.whatHappened}；成立假设=${review.assumptionsValidated || "未填写"}；失败假设=${review.assumptionsFailed || "未填写"}；经验教训=${review.lessons}；原则修订=${review.principleChangesNeeded || "未填写"}。`;
+  const opponentDraft = `请作为投资委员会反方委员，质疑我的复盘是否过于自我宽慰、归因错误或遗漏反证。不要给买入或卖出建议。公司=${company ? `${company.stockName}（${company.stockCode}）` : "未关联"}；实际发生=${review.whatHappened}；失败假设=${review.assumptionsFailed || "未填写"}；经验教训=${review.lessons}。`;
+
+  return (
+    <article className="rounded-lg border border-border bg-background p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="text-sm font-semibold">{labelFor(reviewTypes, review.reviewType)}</div>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {company ? `${company.stockName}（${company.stockCode}）` : "未关联公司"} / {review.reviewDate}
+          </p>
+        </div>
+        <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+          复盘记录
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <InfoBlock title="实际发生" value={review.whatHappened} />
+        <InfoBlock title="经验教训" value={review.lessons} />
+        <InfoBlock title="成立假设" value={review.assumptionsValidated || "未填写"} />
+        <InfoBlock title="失败假设" value={review.assumptionsFailed || "未填写"} />
+      </div>
+
+      {review.principleChangesNeeded ? (
+        <div className="mt-3 rounded-md border border-border bg-card p-3">
+          <div className="text-xs font-semibold text-primary">原则修订建议</div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">{review.principleChangesNeeded}</p>
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Link
+          href={`/mentor?role=mentor&draft=${encodeURIComponent(mentorDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <Bot className="h-4 w-4" aria-hidden />
+          让导师总结
+        </Link>
+        <Link
+          href={`/mentor?role=opponent&draft=${encodeURIComponent(opponentDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <ShieldAlert className="h-4 w-4" aria-hidden />
+          反方追问
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function Field({
+  label,
+  name,
+  type = "text",
+  defaultValue = ""
+}: {
+  label: string;
+  name: string;
+  type?: string;
+  defaultValue?: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <input
+        name={name}
+        type={type}
+        defaultValue={defaultValue}
+        className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function TextArea({ label, name, placeholder }: { label: string; name: string; placeholder: string }) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold">{label}</span>
+      <textarea
+        name={name}
+        placeholder={placeholder}
+        rows={3}
+        className="mt-2 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm leading-6 outline-none transition focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function StatusBanner({ status, message }: { status: "success" | "error"; message: string }) {
+  const Icon = status === "success" ? CheckCircle2 : AlertCircle;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <Icon className="mt-0.5 h-5 w-5 text-primary" aria-hidden />
+        <p className="text-sm leading-6">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function InfoBlock({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="text-xs font-semibold text-primary">{title}</div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{value}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="min-w-20 rounded-md bg-card px-4 py-3">
+      <div className="text-xl font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{label}</div>
+    </div>
   );
 }

--- a/src/db/migrations/0006_amazing_husk.sql
+++ b/src/db/migrations/0006_amazing_husk.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `reviews` (
+	`id` text PRIMARY KEY NOT NULL,
+	`decision_id` text,
+	`company_id` text,
+	`review_type` text DEFAULT 'post_decision' NOT NULL,
+	`review_date` text NOT NULL,
+	`what_happened` text DEFAULT '' NOT NULL,
+	`assumptions_validated` text DEFAULT '' NOT NULL,
+	`assumptions_failed` text DEFAULT '' NOT NULL,
+	`lessons` text DEFAULT '' NOT NULL,
+	`principle_changes_needed` text DEFAULT '' NOT NULL,
+	`ai_summary` text DEFAULT '' NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`decision_id`) REFERENCES `decisions`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE set null
+);

--- a/src/db/migrations/meta/0006_snapshot.json
+++ b/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1201 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1c20c6a9-4656-48ee-a4ac-8f2d4e8bd3c4",
+  "prevId": "d2f3a0f6-ef72-42cd-8364-02aa06bf9dbb",
+  "tables": {
+    "ai_conversations": {
+      "name": "ai_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_conversations_provider_id_model_providers_id_fk": {
+          "name": "ai_conversations_provider_id_model_providers_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_messages": {
+      "name": "ai_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_messages_conversation_id_ai_conversations_id_fk": {
+          "name": "ai_messages_conversation_id_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checklist_runs": {
+      "name": "checklist_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_type": {
+          "name": "checklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "final_judgment": {
+          "name": "final_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_runs_company_id_companies_id_fk": {
+          "name": "checklist_runs_company_id_companies_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "checklist_runs_principle_id_investment_principles_id_fk": {
+          "name": "checklist_runs_principle_id_investment_principles_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_code": {
+          "name": "stock_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_name": {
+          "name": "stock_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "watch_status": {
+          "name": "watch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'watching'"
+        },
+        "valuation_status": {
+          "name": "valuation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "in_circle": {
+          "name": "in_circle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "thesis": {
+          "name": "thesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "key_risks": {
+          "name": "key_risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decisions": {
+      "name": "decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checklist_run_id": {
+          "name": "checklist_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_type": {
+          "name": "decision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "final_user_judgment": {
+          "name": "final_user_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_assumptions": {
+          "name": "key_assumptions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risks": {
+          "name": "risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "opponent_summary": {
+          "name": "opponent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "decision_date": {
+          "name": "decision_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "decisions_company_id_companies_id_fk": {
+          "name": "decisions_company_id_companies_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_checklist_run_id_checklist_runs_id_fk": {
+          "name": "decisions_checklist_run_id_checklist_runs_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "checklist_runs",
+          "columnsFrom": [
+            "checklist_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_principle_id_investment_principles_id_fk": {
+          "name": "decisions_principle_id_investment_principles_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "investment_principles": {
+      "name": "investment_principles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'我的 A 股价值投资原则'"
+        },
+        "circle_of_competence": {
+          "name": "circle_of_competence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "excluded_industries": {
+          "name": "excluded_industries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_financial_quality": {
+          "name": "minimum_financial_quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_margin_of_safety": {
+          "name": "minimum_margin_of_safety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_rules": {
+          "name": "position_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "buy_rules": {
+          "name": "buy_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sell_rules": {
+          "name": "sell_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_nothing_rules": {
+          "name": "do_nothing_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risk_rules": {
+          "name": "risk_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_nodes": {
+      "name": "knowledge_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_configs_provider_id_model_providers_id_fk": {
+          "name": "model_configs_provider_id_model_providers_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_providers": {
+      "name": "model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_openai_compatible": {
+          "name": "is_openai_compatible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_insecure_tls": {
+          "name": "allow_insecure_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_name": {
+          "name": "default_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_temperature": {
+          "name": "default_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "max_context_tokens": {
+          "name": "max_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8000
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_tested'"
+        },
+        "last_test_message": {
+          "name": "last_test_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_type": {
+          "name": "review_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'post_decision'"
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "what_happened": {
+          "name": "what_happened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assumptions_validated": {
+          "name": "assumptions_validated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assumptions_failed": {
+          "name": "assumptions_failed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lessons": {
+          "name": "lessons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "principle_changes_needed": {
+          "name": "principle_changes_needed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_decision_id_decisions_id_fk": {
+          "name": "reviews_decision_id_decisions_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_company_id_companies_id_fk": {
+          "name": "reviews_company_id_companies_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "valuations": {
+      "name": "valuations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_type": {
+          "name": "template_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "valuation_date": {
+          "name": "valuation_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shares_outstanding": {
+          "name": "shares_outstanding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CNY'"
+        },
+        "scenario_bear_json": {
+          "name": "scenario_bear_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_base_json": {
+          "name": "scenario_base_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_bull_json": {
+          "name": "scenario_bull_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "valuations_company_id_companies_id_fk": {
+          "name": "valuations_company_id_companies_id_fk",
+          "tableFrom": "valuations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777705793377,
       "tag": "0005_lush_bruce_banner",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1777706205950,
+      "tag": "0006_amazing_husk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -146,3 +146,19 @@ export const valuations = sqliteTable("valuations", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull()
 });
+
+export const reviews = sqliteTable("reviews", {
+  id: text("id").primaryKey(),
+  decisionId: text("decision_id").references(() => decisions.id, { onDelete: "set null" }),
+  companyId: text("company_id").references(() => companies.id, { onDelete: "set null" }),
+  reviewType: text("review_type").notNull().default("post_decision"),
+  reviewDate: text("review_date").notNull(),
+  whatHappened: text("what_happened").notNull().default(""),
+  assumptionsValidated: text("assumptions_validated").notNull().default(""),
+  assumptionsFailed: text("assumptions_failed").notNull().default(""),
+  lessons: text("lessons").notNull().default(""),
+  principleChangesNeeded: text("principle_changes_needed").notNull().default(""),
+  aiSummary: text("ai_summary").notNull().default(""),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});

--- a/src/lib/reviews/constants.ts
+++ b/src/lib/reviews/constants.ts
@@ -1,0 +1,10 @@
+export const reviewTypes = [
+  { value: "post_decision", label: "单次决策复盘" },
+  { value: "quarterly", label: "季度复盘" },
+  { value: "annual", label: "年度复盘" },
+  { value: "mistake", label: "错误案例复盘" }
+] as const;
+
+export function labelFor<T extends { value: string; label: string }>(options: readonly T[], value: string) {
+  return options.find((option) => option.value === value)?.label ?? value;
+}

--- a/src/lib/reviews/queries.ts
+++ b/src/lib/reviews/queries.ts
@@ -1,0 +1,33 @@
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { companies, decisions, reviews } from "@/db/schema";
+
+export async function getReviewsPageData() {
+  const [decisionRows, reviewRows] = await Promise.all([
+    db
+      .select({
+        decision: decisions,
+        company: companies
+      })
+      .from(decisions)
+      .leftJoin(companies, eq(decisions.companyId, companies.id))
+      .orderBy(desc(decisions.createdAt))
+      .limit(20),
+    db
+      .select({
+        review: reviews,
+        decision: decisions,
+        company: companies
+      })
+      .from(reviews)
+      .leftJoin(decisions, eq(reviews.decisionId, decisions.id))
+      .leftJoin(companies, eq(reviews.companyId, companies.id))
+      .orderBy(desc(reviews.createdAt))
+      .limit(10)
+  ]);
+
+  return {
+    decisions: decisionRows,
+    reviews: reviewRows
+  };
+}


### PR DESCRIPTION
## 关联 Issue\n\nCloses #15\n\n## 改动摘要\n\n- 将复盘占位页升级为可用的复盘工作台。\n- 支持选择已有决策并创建复盘记录。\n- 支持记录实际发生情况、成立假设、失败假设、经验教训和原则修订建议。\n- 最近复盘提供 AI 导师总结和反方追问入口，不输出买卖建议。\n\n## 主要文件\n\n- app/reviews/page.tsx\n- app/reviews/actions.ts\n- src/lib/reviews/constants.ts\n- src/lib/reviews/queries.ts\n- src/db/schema.ts\n- src/db/migrations/0006_amazing_husk.sql\n\n## 验证\n\n- [x] npm run db:generate\n- [x] npm run db:migrate\n- [x] npm run typecheck\n- [x] npm run build\n- [x] 重启 next dev 后验证 /reviews 返回 200\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n\n## 截图 / 说明\n\n/reviews 页面包含创建复盘和最近复盘两个区域。MVP 第一版以定性复盘为主，先完成从决策到复盘的闭环。\n\n## 数据库迁移\n\n新增 reviews 表，用于保存关联决策、公司、复盘类型、实际发生、假设验证、经验教训和原则修订建议。\n\n## 风险\n\n- 第一版不接入收益率或行情数据，复盘内容由用户手动记录。\n- 第一版不自动修订投资原则，只生成用户可参考的修订建议。\n\n## 回退方案\n\n回退本 PR 可恢复复盘占位页；新增 reviews 表不会影响已有模块。