### PR TITLE
feat: add local JSON export

### DIFF
--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db/client";
+import {
+  aiConversations,
+  aiMessages,
+  checklistRuns,
+  companies,
+  decisions,
+  investmentPrinciples,
+  knowledgeNodes,
+  modelConfigs,
+  modelProviders,
+  reviews,
+  valuations
+} from "@/db/schema";
+
+export async function GET() {
+  const [
+    providerRows,
+    configRows,
+    conversationRows,
+    messageRows,
+    knowledgeRows,
+    companyRows,
+    principleRows,
+    checklistRunRows,
+    decisionRows,
+    valuationRows,
+    reviewRows
+  ] = await Promise.all([
+    db
+      .select({
+        id: modelProviders.id,
+        name: modelProviders.name,
+        apiBaseUrl: modelProviders.apiBaseUrl,
+        isOpenAICompatible: modelProviders.isOpenAICompatible,
+        allowInsecureTls: modelProviders.allowInsecureTls,
+        defaultModelName: modelProviders.defaultModelName,
+        defaultTemperature: modelProviders.defaultTemperature,
+        maxContextTokens: modelProviders.maxContextTokens,
+        status: modelProviders.status,
+        lastTestStatus: modelProviders.lastTestStatus,
+        lastTestMessage: modelProviders.lastTestMessage,
+        lastTestedAt: modelProviders.lastTestedAt,
+        createdAt: modelProviders.createdAt,
+        updatedAt: modelProviders.updatedAt
+      })
+      .from(modelProviders),
+    db.select().from(modelConfigs),
+    db.select().from(aiConversations),
+    db.select().from(aiMessages),
+    db.select().from(knowledgeNodes),
+    db.select().from(companies),
+    db.select().from(investmentPrinciples),
+    db.select().from(checklistRuns),
+    db.select().from(decisions),
+    db.select().from(valuations),
+    db.select().from(reviews)
+  ]);
+
+  const exportedAt = new Date().toISOString();
+  const payload = {
+    app: "Value Compass",
+    version: 1,
+    exportedAt,
+    notice: "导出文件不包含模型 API Key；仍可能包含你的研究记录、决策和复盘内容，请妥善保存。",
+    data: {
+      modelProviders: providerRows,
+      modelConfigs: configRows,
+      aiConversations: conversationRows,
+      aiMessages: messageRows,
+      knowledgeNodes: knowledgeRows,
+      companies: companyRows,
+      investmentPrinciples: principleRows,
+      checklistRuns: checklistRunRows,
+      decisions: decisionRows,
+      valuations: valuationRows,
+      reviews: reviewRows
+    }
+  };
+
+  return new NextResponse(JSON.stringify(payload, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Disposition": `attachment; filename="value-compass-export-${exportedAt.slice(0, 10)}.json"`
+    }
+  });
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Bot, CheckCircle2, KeyRound } from "lucide-react";
+import { AlertCircle, Bot, CheckCircle2, Download, KeyRound } from "lucide-react";
 import {
   saveModelProvider,
 } from "./actions";
@@ -121,6 +121,25 @@ export default async function SettingsPage({ searchParams }: SettingsPageProps) 
             ))
           )}
         </div>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <SectionHeader
+            title="本地数据备份"
+            description="导出观察池、估值、原则、检查、决策、复盘和 AI 对话记录。导出文件不包含模型 API Key。"
+          />
+          <a
+            href="/api/export"
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-semibold transition hover:bg-muted"
+          >
+            <Download className="h-4 w-4" aria-hidden />
+            导出 JSON
+          </a>
+        </div>
+        <p className="mt-3 text-xs leading-5 text-muted-foreground">
+          导出文件可能包含你的研究记录和决策复盘，请保存在你信任的位置。导入恢复功能放在后续版本。
+        </p>
       </section>
     </main>
   );


### PR DESCRIPTION
## 关联 Issue\n\nCloses #17\n\n## 改动摘要\n\n- 新增 /api/export 本地 JSON 导出接口。\n- 设置页新增本地数据备份区域和导出入口。\n- 导出模型提供商元信息但不导出 apiKeyEncrypted。\n\n## 主要文件\n\n- app/api/export/route.ts\n- app/settings/page.tsx\n\n## 验证\n\n- [x] npm run typecheck\n- [x] npm run build\n- [x] /api/export 返回 JSON 附件响应\n- [x] 导出内容检查未出现 apiKeyEncrypted 字段\n- [x] 重启 next dev 后验证设置页显示导出入口\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n\n## 截图 / 说明\n\n/settings 页面新增本地数据备份区。导出文件包含模型元信息、AI 对话、知识节点、观察池、估值、原则、检查、决策和复盘，不包含模型 API Key。\n\n## 数据库迁移\n\n无。\n\n## 风险\n\n导出文件仍可能包含用户自己的研究记录、决策和复盘内容，需要用户自行妥善保管。\n\n## 回退方案\n\n回退本 PR 即移除导出接口和设置页入口。