### PR TITLE
feat: add AI research extraction

### DIFF
--- a/app/api/watchlist/extract/route.ts
+++ b/app/api/watchlist/extract/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { callOpenAICompatibleChat } from "@/lib/ai/openai-compatible";
+import { decryptSecret } from "@/lib/encryption/crypto";
+import { getModelProviderForRole } from "@/lib/model-config/queries";
+import { companyTypes } from "@/lib/watchlist/constants";
+
+const extractRequestSchema = z.object({
+  company: z.object({
+    stockCode: z.string().trim().min(1),
+    stockName: z.string().trim().min(1),
+    industry: z.string().trim().optional(),
+    companyType: z.string().trim().optional(),
+    description: z.string().trim().optional(),
+    thesis: z.string().trim().optional(),
+    keyRisks: z.string().trim().optional(),
+    nextAction: z.string().trim().optional()
+  }),
+  sourceText: z.string().trim().min(80, "请至少粘贴 80 个字的资料。").max(12000, "单次资料不能超过 12000 字。")
+});
+
+const extractResponseSchema = z.object({
+  industry: z.string().trim().default(""),
+  companyType: z.string().trim().default("other"),
+  description: z.string().trim().default(""),
+  thesis: z.string().trim().default(""),
+  keyRisks: z.string().trim().default(""),
+  nextAction: z.string().trim().default(""),
+  facts: z.array(z.string().trim()).default([]),
+  inferences: z.array(z.string().trim()).default([]),
+  opinions: z.array(z.string().trim()).default([]),
+  toVerify: z.array(z.string().trim()).default([])
+});
+
+const allowedCompanyTypeValues = companyTypes.map((type) => type.value).join(", ");
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const parsed = extractRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message: parsed.error.issues[0]?.message ?? "请求格式不正确。"
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const modelConfig = await getModelProviderForRole("research_assistant");
+
+    if (!modelConfig) {
+      throw new Error("还没有可用的模型配置。请先到设置页新增并测试模型提供商。");
+    }
+
+    const rawContent = await callOpenAICompatibleChat({
+      config: {
+        apiBaseUrl: modelConfig.provider.apiBaseUrl,
+        apiKey: decryptSecret(modelConfig.provider.apiKeyEncrypted),
+        model: modelConfig.modelName,
+        temperature: Math.min(modelConfig.temperature / 100, 0.2),
+        allowInsecureTls: modelConfig.provider.allowInsecureTls
+      },
+      messages: [
+        {
+          role: "system",
+          content: `你是 A 股价值投资研究助理。你的任务是从用户粘贴的资料中提取结构化研究草稿。
+
+严格规则：
+- 只返回 JSON，不要使用 Markdown。
+- 不输出买入、卖出、持有、目标价、仓位建议。
+- 区分事实、推断、观点和待确认事项。
+- 不要编造资料中没有的信息；不确定就写入 toVerify。
+- companyType 只能从这些值选择：${allowedCompanyTypeValues}。
+- nextAction 应该是研究动作，例如阅读年报、核对财务数据、补估值、验证风险，不是交易动作。
+
+JSON 字段：
+{
+  "industry": "",
+  "companyType": "consumer|financial|cyclical|manufacturing|healthcare|technology|other",
+  "description": "",
+  "thesis": "",
+  "keyRisks": "",
+  "nextAction": "",
+  "facts": [],
+  "inferences": [],
+  "opinions": [],
+  "toVerify": []
+}`
+        },
+        {
+          role: "user",
+          content: `公司上下文：
+股票代码：${parsed.data.company.stockCode}
+公司名称：${parsed.data.company.stockName}
+已有行业：${parsed.data.company.industry || "未填写"}
+已有公司类型：${parsed.data.company.companyType || "未填写"}
+已有简介：${parsed.data.company.description || "未填写"}
+已有投资假设：${parsed.data.company.thesis || "未填写"}
+已有关键风险：${parsed.data.company.keyRisks || "未填写"}
+已有下一步行动：${parsed.data.company.nextAction || "未填写"}
+
+用户粘贴资料：
+${parsed.data.sourceText}`
+        }
+      ]
+    });
+
+    const json = extractJson(rawContent);
+    const extracted = extractResponseSchema.parse(json);
+    const normalizedCompanyType = companyTypes.some((type) => type.value === extracted.companyType)
+      ? extracted.companyType
+      : "other";
+
+    return NextResponse.json({
+      ok: true,
+      draft: {
+        ...extracted,
+        companyType: normalizedCompanyType
+      }
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        message: error instanceof Error ? error.message : "AI 资料提取失败。"
+      },
+      { status: 500 }
+    );
+  }
+}
+
+function extractJson(content: string) {
+  const trimmed = content.trim();
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    const match = trimmed.match(/\{[\s\S]*\}/);
+
+    if (!match) {
+      throw new Error("模型没有返回可解析的 JSON 草稿。");
+    }
+
+    return JSON.parse(match[0]) as unknown;
+  }
+}

--- a/app/watchlist/actions.ts
+++ b/app/watchlist/actions.ts
@@ -25,6 +25,16 @@ const updateSchema = companySchema.extend({
   companyId: z.string().trim().min(1)
 });
 
+const extractionDraftSchema = z.object({
+  companyId: z.string().trim().min(1),
+  industry: z.string().trim().default(""),
+  companyType: z.string().trim().default("other"),
+  description: z.string().trim().default(""),
+  thesis: z.string().trim().default(""),
+  keyRisks: z.string().trim().default(""),
+  nextAction: z.string().trim().default("")
+});
+
 function now() {
   return new Date().toISOString();
 }
@@ -94,6 +104,35 @@ export async function updateCompany(formData: FormData) {
     .set({
       ...values,
       stockCode: normalizeCode(values.stockCode),
+      updatedAt: now()
+    })
+    .where(eq(companies.id, companyId));
+
+  revalidatePath("/watchlist");
+}
+
+export async function applyExtractionDraft(formData: FormData) {
+  const parsed = extractionDraftSchema.safeParse({
+    companyId: formData.get("companyId"),
+    industry: formData.get("industry"),
+    companyType: formData.get("companyType"),
+    description: formData.get("description"),
+    thesis: formData.get("thesis"),
+    keyRisks: formData.get("keyRisks"),
+    nextAction: formData.get("nextAction")
+  });
+
+  if (!parsed.success) {
+    return;
+  }
+
+  const { companyId, ...values } = parsed.data;
+
+  await db
+    .update(companies)
+    .set({
+      ...values,
+      watchStatus: "researching",
       updatedAt: now()
     })
     .where(eq(companies.id, companyId));

--- a/app/watchlist/page.tsx
+++ b/app/watchlist/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { Bot, Building2, CheckCircle2, ShieldAlert } from "lucide-react";
 import { PendingButton } from "@/components/ui/pending-button";
-import { addCompany, updateCompany } from "./actions";
+import { ResearchExtractionPanel } from "@/components/watchlist/research-extraction-panel";
+import { addCompany, applyExtractionDraft, updateCompany } from "./actions";
 import type { companies } from "@/db/schema";
 import {
   companyTypes,
@@ -36,6 +37,8 @@ export default async function WatchlistPage() {
           </div>
         </div>
       </section>
+
+      <ResearchExtractionPanel companies={watchlist} applyAction={applyExtractionDraft} />
 
       <section className="grid gap-6 xl:grid-cols-[420px_1fr]">
         <div className="rounded-lg border border-border bg-card p-5">

--- a/src/components/watchlist/research-extraction-panel.tsx
+++ b/src/components/watchlist/research-extraction-panel.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Bot, CheckCircle2, FileText, Sparkles } from "lucide-react";
+import { PendingButton } from "@/components/ui/pending-button";
+import type { companies } from "@/db/schema";
+import { companyTypes, labelFor } from "@/lib/watchlist/constants";
+
+type Company = typeof companies.$inferSelect;
+
+type ExtractionDraft = {
+  industry: string;
+  companyType: string;
+  description: string;
+  thesis: string;
+  keyRisks: string;
+  nextAction: string;
+  facts: string[];
+  inferences: string[];
+  opinions: string[];
+  toVerify: string[];
+};
+
+export function ResearchExtractionPanel({
+  companies,
+  applyAction
+}: {
+  companies: Company[];
+  applyAction: (formData: FormData) => Promise<void>;
+}) {
+  const [companyId, setCompanyId] = useState(companies[0]?.id ?? "");
+  const [sourceText, setSourceText] = useState("");
+  const [draft, setDraft] = useState<ExtractionDraft | null>(null);
+  const [isExtracting, setIsExtracting] = useState(false);
+  const [message, setMessage] = useState("");
+  const selectedCompany = useMemo(
+    () => companies.find((company) => company.id === companyId) ?? companies[0],
+    [companies, companyId]
+  );
+
+  async function extractDraft() {
+    if (!selectedCompany || isExtracting) {
+      return;
+    }
+
+    setIsExtracting(true);
+    setMessage("");
+    setDraft(null);
+
+    try {
+      const response = await fetch("/api/watchlist/extract", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          company: {
+            stockCode: selectedCompany.stockCode,
+            stockName: selectedCompany.stockName,
+            industry: selectedCompany.industry,
+            companyType: selectedCompany.companyType,
+            description: selectedCompany.description,
+            thesis: selectedCompany.thesis,
+            keyRisks: selectedCompany.keyRisks,
+            nextAction: selectedCompany.nextAction
+          },
+          sourceText
+        })
+      });
+      const data = (await response.json()) as {
+        ok?: boolean;
+        message?: string;
+        draft?: ExtractionDraft;
+      };
+
+      if (!response.ok || !data.ok || !data.draft) {
+        throw new Error(data.message ?? "AI 资料提取失败。");
+      }
+
+      setDraft(data.draft);
+      setMessage("已生成待确认草稿。请先检查，再决定是否应用到公司记录。");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "AI 资料提取失败。");
+    } finally {
+      setIsExtracting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-primary" aria-hidden />
+            <h2 className="text-xl font-semibold">AI 资料提取</h2>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+            粘贴年报、公告、新闻、研报摘要或你的笔记，让 AI 生成待确认草稿。资料会发送给你配置的模型提供商；AI 不会自动覆盖记录。
+          </p>
+        </div>
+        <div className="rounded-md border border-border bg-background px-3 py-2 text-xs leading-5 text-muted-foreground">
+          事实 / 推断 / 观点 / 待确认分开展示
+        </div>
+      </div>
+
+      {companies.length === 0 ? (
+        <div className="mt-5 rounded-lg border border-dashed border-border bg-background p-6 text-sm leading-6 text-muted-foreground">
+          先新增一家公司，再使用 AI 资料提取。
+        </div>
+      ) : (
+        <div className="mt-5 grid gap-5 xl:grid-cols-[0.9fr_1.1fr]">
+          <div className="space-y-4">
+            <label className="block">
+              <span className="text-sm font-semibold">目标公司</span>
+              <select
+                value={companyId}
+                onChange={(event) => {
+                  setCompanyId(event.target.value);
+                  setDraft(null);
+                  setMessage("");
+                }}
+                className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+              >
+                {companies.map((company) => (
+                  <option key={company.id} value={company.id}>
+                    {company.stockName}（{company.stockCode}）
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-sm font-semibold">粘贴资料</span>
+              <textarea
+                value={sourceText}
+                onChange={(event) => setSourceText(event.target.value)}
+                rows={9}
+                placeholder="粘贴年报段落、公告摘要、新闻、研报摘要或你的研究笔记。"
+                className="mt-2 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm leading-6 outline-none transition focus:border-primary"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={extractDraft}
+              disabled={!selectedCompany || sourceText.trim().length < 80 || isExtracting}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+            >
+              <Bot className="h-4 w-4" aria-hidden />
+              {isExtracting ? "提取中..." : "生成待确认草稿"}
+            </button>
+            {message ? (
+              <div className="rounded-md border border-border bg-background p-3 text-sm leading-6 text-muted-foreground">
+                {message}
+              </div>
+            ) : null}
+          </div>
+
+          <DraftPreview companyId={selectedCompany?.id ?? ""} draft={draft} applyAction={applyAction} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DraftPreview({
+  companyId,
+  draft,
+  applyAction
+}: {
+  companyId: string;
+  draft: ExtractionDraft | null;
+  applyAction: (formData: FormData) => Promise<void>;
+}) {
+  if (!draft) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-background p-6">
+        <div className="flex items-start gap-3">
+          <FileText className="mt-0.5 h-5 w-5 text-primary" aria-hidden />
+          <div>
+            <p className="text-sm font-semibold">草稿会显示在这里</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              提取结果不会自动写入公司记录。你可以先阅读事实和待确认事项，再决定是否应用。
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border bg-background p-4">
+      <div className="grid gap-3 md:grid-cols-2">
+        <DraftField title="行业" value={draft.industry || "未识别"} />
+        <DraftField title="公司类型" value={labelFor(companyTypes, draft.companyType)} />
+        <DraftField title="公司简介" value={draft.description || "未提取"} />
+        <DraftField title="投资假设草稿" value={draft.thesis || "未提取"} />
+        <DraftField title="关键风险草稿" value={draft.keyRisks || "未提取"} />
+        <DraftField title="下一步行动" value={draft.nextAction || "未提取"} />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <ListBlock title="事实" items={draft.facts} />
+        <ListBlock title="推断" items={draft.inferences} />
+        <ListBlock title="观点" items={draft.opinions} />
+        <ListBlock title="待确认" items={draft.toVerify} />
+      </div>
+
+      <form action={applyAction}>
+        <input type="hidden" name="companyId" value={companyId} />
+        <input type="hidden" name="industry" value={draft.industry} />
+        <input type="hidden" name="companyType" value={draft.companyType} />
+        <input type="hidden" name="description" value={draft.description} />
+        <input type="hidden" name="thesis" value={draft.thesis} />
+        <input type="hidden" name="keyRisks" value={draft.keyRisks} />
+        <input type="hidden" name="nextAction" value={draft.nextAction} />
+        <PendingButton
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+          pendingChildren="应用中..."
+        >
+          <CheckCircle2 className="h-4 w-4" aria-hidden />
+          应用到公司记录
+        </PendingButton>
+      </form>
+    </div>
+  );
+}
+
+function DraftField({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="text-xs font-semibold text-primary">{title}</div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{value}</p>
+    </div>
+  );
+}
+
+function ListBlock({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="text-xs font-semibold text-primary">{title}</div>
+      {items.length === 0 ? (
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">无</p>
+      ) : (
+        <ul className="mt-2 space-y-1 text-sm leading-6 text-muted-foreground">
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 关联 Issue\n\nCloses #21\n\n## 改动摘要\n\n- 在观察池新增 AI 资料提取面板。\n- 用户可选择公司并粘贴年报、公告、新闻、研报摘要或个人笔记。\n- 新增 /api/watchlist/extract，调用 research_assistant 模型生成结构化待确认草稿。\n- 草稿区分事实、推断、观点和待确认事项。\n- 用户点击应用后才更新公司记录，并将研究状态置为深研中。\n\n## 主要文件\n\n- app/api/watchlist/extract/route.ts\n- src/components/watchlist/research-extraction-panel.tsx\n- app/watchlist/page.tsx\n- app/watchlist/actions.ts\n\n## 验证\n\n- [x] npm run typecheck\n- [x] npm run build\n- [x] 重启 next dev 后验证 /watchlist 返回 200\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n- [x] /api/watchlist/extract 对过短资料返回清晰错误提示\n\n## 截图 / 说明\n\n观察池页面新增 AI 资料提取区域。该功能不联网搜索，仅处理用户主动粘贴的资料；资料会发送给用户配置的模型提供商。\n\n## 数据库迁移\n\n无。\n\n## 风险\n\nAI 可能误读或遗漏资料，因此结果只作为待确认草稿，不自动覆盖原记录。\n\n## 回退方案\n\n回退本 PR 即移除资料提取入口和 API，不影响已有观察池数据。