### PR TITLE
feat: add valuation sensitivity chart

### DIFF
--- a/app/valuations/page.tsx
+++ b/app/valuations/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { AlertCircle, Bot, Calculator, CheckCircle2, ShieldAlert, Sigma } from "lucide-react";
 import { PendingButton } from "@/components/ui/pending-button";
 import { SectionHeader } from "@/components/ui/section-header";
+import { SensitivityChartLazy } from "@/components/valuations/sensitivity-chart-lazy";
 import type { companies, valuations } from "@/db/schema";
 import type { ValuationResult, ValuationScenarioInput } from "@/lib/valuations/calculations";
 import {
@@ -272,6 +273,14 @@ function ValuationCard({ valuation, company }: { valuation: Valuation; company: 
         <InfoBlock title="中性情景" value={`${formatNumber(result.baseValuePerShare)} 元/股`} />
         <InfoBlock title="安全边际" value={formatPercent(result.baseMarginOfSafety)} />
       </div>
+
+      <SensitivityChartLazy
+        currentPrice={currentPrice}
+        data={result.scenarioResults.map((scenario) => ({
+          name: labelFor(scenarios, scenario.name),
+          valuePerShare: scenario.valuePerShare
+        }))}
+      />
 
       {result.riskFlags.length > 0 ? (
         <div className="mt-4 rounded-md border border-border bg-card p-3">

--- a/src/components/valuations/sensitivity-chart-lazy.tsx
+++ b/src/components/valuations/sensitivity-chart-lazy.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const SensitivityChart = dynamic(() => import("@/components/valuations/sensitivity-chart"), {
+  ssr: false,
+  loading: () => (
+    <div className="mt-4 h-56 rounded-md border border-border bg-card p-3 text-sm text-muted-foreground">
+      正在加载估值图表...
+    </div>
+  )
+});
+
+export function SensitivityChartLazy({
+  data,
+  currentPrice
+}: {
+  data: Array<{ name: string; valuePerShare: number }>;
+  currentPrice: number;
+}) {
+  return <SensitivityChart data={data} currentPrice={currentPrice} />;
+}

--- a/src/components/valuations/sensitivity-chart.tsx
+++ b/src/components/valuations/sensitivity-chart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from "recharts";
+
+type SensitivityPoint = {
+  name: string;
+  valuePerShare: number;
+};
+
+export default function SensitivityChart({
+  data,
+  currentPrice
+}: {
+  data: SensitivityPoint[];
+  currentPrice: number;
+}) {
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-4 rounded-md border border-border bg-card p-3">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-xs font-semibold text-primary">三情景估值图</div>
+        <div className="text-xs text-muted-foreground">虚线为当前价格</div>
+      </div>
+      <div className="mt-3 h-56 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+            <CartesianGrid stroke="hsl(var(--border))" vertical={false} />
+            <XAxis
+              dataKey="name"
+              tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
+              tickLine={false}
+              axisLine={{ stroke: "hsl(var(--border))" }}
+            />
+            <YAxis
+              tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
+              tickLine={false}
+              axisLine={false}
+              width={44}
+              tickFormatter={(value) => `${value}`}
+            />
+            <Tooltip
+              cursor={{ fill: "hsl(var(--muted))" }}
+              formatter={(value) => [`${Number(value).toFixed(2)} 元/股`, "每股估值"]}
+              labelFormatter={(label) => `${label}情景`}
+              contentStyle={{
+                border: "1px solid hsl(var(--border))",
+                borderRadius: 8,
+                background: "hsl(var(--card))",
+                color: "hsl(var(--foreground))"
+              }}
+            />
+            {currentPrice > 0 ? (
+              <ReferenceLine
+                y={currentPrice}
+                stroke="hsl(var(--primary))"
+                strokeDasharray="4 4"
+                label={{
+                  value: `当前 ${currentPrice.toFixed(2)}`,
+                  fill: "hsl(var(--primary))",
+                  fontSize: 12,
+                  position: "insideTopRight"
+                }}
+              />
+            ) : null}
+            <Bar dataKey="valuePerShare" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 关联 Issue\n\nCloses #23\n\n## 改动摘要\n\n- 最近估值卡片新增三情景估值图。\n- 图表显示悲观、中性、乐观每股估值。\n- 当前价格以虚线参考线显示。\n- 使用动态加载 Recharts，避免估值页首包显著增大。\n\n## 主要文件\n\n- app/valuations/page.tsx\n- src/components/valuations/sensitivity-chart.tsx\n- src/components/valuations/sensitivity-chart-lazy.tsx\n\n## 验证\n\n- [x] npm run typecheck\n- [x] npm run build\n- [x] 构建后 /valuations 首包保持约 1.56 kB，图表懒加载\n- [x] 重启 next dev 后验证 /valuations 返回 200\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n\n## 数据库迁移\n\n无。\n\n## 风险\n\n第一版只展示三情景结果，不做多参数敏感性矩阵。\n\n## 回退方案\n\n回退本 PR 即恢复原有数字卡片展示。