### PR TITLE
feat: add custom checklist templates

### DIFF
--- a/app/system/actions.ts
+++ b/app/system/actions.ts
@@ -5,9 +5,9 @@ import { redirect } from "next/navigation";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
-import { checklistRuns, decisions, investmentPrinciples } from "@/db/schema";
-import { checklistTemplates, checklistTypes, labelFor } from "@/lib/investment-system/constants";
-import { getActiveInvestmentPrinciple } from "@/lib/investment-system/queries";
+import { checklistRuns, customChecklistTemplates, decisions, investmentPrinciples } from "@/db/schema";
+import { checklistTypes, labelFor, type ChecklistTemplateItem } from "@/lib/investment-system/constants";
+import { getActiveInvestmentPrinciple, getEffectiveChecklistTemplate } from "@/lib/investment-system/queries";
 
 const principleSchema = z.object({
   principleId: z.string().optional(),
@@ -30,6 +30,11 @@ const runSchema = z.object({
   keyAssumptions: z.string().trim().default(""),
   risks: z.string().trim().default(""),
   summary: z.string().trim().default("")
+});
+
+const templateSchema = z.object({
+  checklistType: z.enum(["buy", "sell", "do_nothing"]),
+  title: z.string().trim().min(1, "请填写模板名称。")
 });
 
 function now() {
@@ -110,8 +115,8 @@ export async function saveChecklistRun(formData: FormData) {
     statusRedirect("error", parsed.error.issues[0]?.message ?? "检查清单校验失败。");
   }
 
-  const template = checklistTemplates[parsed.data.checklistType];
-  const items = template.map((item) => {
+  const template = await getEffectiveChecklistTemplate(parsed.data.checklistType);
+  const items = template.items.map((item) => {
     const status = String(formData.get(`status.${item.id}`) ?? "unknown");
     const normalizedStatus = ["pass", "fail", "unknown", "not_applicable"].includes(status)
       ? status
@@ -168,4 +173,64 @@ export async function saveChecklistRun(formData: FormData) {
 
   revalidatePath("/system");
   statusRedirect("success", "检查清单和决策记录已保存。");
+}
+
+export async function saveChecklistTemplate(formData: FormData) {
+  const parsed = templateSchema.safeParse({
+    checklistType: formData.get("checklistType"),
+    title: formData.get("title")
+  });
+
+  if (!parsed.success) {
+    statusRedirect("error", parsed.error.issues[0]?.message ?? "清单模板校验失败。");
+  }
+
+  const items = Array.from({ length: 8 }, (_, index) => {
+    const text = String(formData.get(`itemText.${index}`) ?? "").trim();
+    const category = String(formData.get(`itemCategory.${index}`) ?? "").trim() || "通用";
+    const required = formData.get(`itemRequired.${index}`) === "on";
+
+    return {
+      id: `${parsed.data.checklistType}_${index + 1}`,
+      text,
+      category,
+      required
+    };
+  }).filter((item): item is ChecklistTemplateItem => Boolean(item.text));
+
+  if (items.length === 0) {
+    statusRedirect("error", "至少保留 1 个检查项。");
+  }
+
+  const timestamp = now();
+  const [existingTemplate] = await db
+    .select()
+    .from(customChecklistTemplates)
+    .where(eq(customChecklistTemplates.checklistType, parsed.data.checklistType))
+    .limit(1);
+
+  if (existingTemplate) {
+    await db
+      .update(customChecklistTemplates)
+      .set({
+        title: parsed.data.title,
+        itemsJson: JSON.stringify(items),
+        active: true,
+        updatedAt: timestamp
+      })
+      .where(eq(customChecklistTemplates.id, existingTemplate.id));
+  } else {
+    await db.insert(customChecklistTemplates).values({
+      id: crypto.randomUUID(),
+      checklistType: parsed.data.checklistType,
+      title: parsed.data.title,
+      itemsJson: JSON.stringify(items),
+      active: true,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    });
+  }
+
+  revalidatePath("/system");
+  statusRedirect("success", "检查清单模板已保存。");
 }

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -13,14 +13,14 @@ import { SectionHeader } from "@/components/ui/section-header";
 import type { checklistRuns, companies, decisions, investmentPrinciples } from "@/db/schema";
 import {
   checklistStatuses,
-  checklistTemplates,
   checklistTypes,
   labelFor,
+  type EffectiveChecklistTemplate,
   type ChecklistTemplateItem,
   type ChecklistType
 } from "@/lib/investment-system/constants";
 import { getSystemPageData } from "@/lib/investment-system/queries";
-import { saveChecklistRun, saveInvestmentPrinciple } from "./actions";
+import { saveChecklistRun, saveChecklistTemplate, saveInvestmentPrinciple } from "./actions";
 
 type SystemPageProps = {
   searchParams?: Promise<{
@@ -65,8 +65,14 @@ export default async function SystemPage({ searchParams }: SystemPageProps) {
 
       <section className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
         <PrinciplePanel principle={data.principle} />
-        <ChecklistPanel principle={data.principle} companies={data.companies} />
+        <ChecklistPanel
+          principle={data.principle}
+          companies={data.companies}
+          templates={data.checklistTemplates}
+        />
       </section>
+
+      <ChecklistTemplateEditor templates={data.checklistTemplates} />
 
       <section className="grid gap-6 xl:grid-cols-2">
         <RecentRuns runs={data.recentRuns} principle={data.principle} />
@@ -122,7 +128,15 @@ function PrinciplePanel({ principle }: { principle?: Principle }) {
   );
 }
 
-function ChecklistPanel({ principle, companies }: { principle?: Principle; companies: Company[] }) {
+function ChecklistPanel({
+  principle,
+  companies,
+  templates
+}: {
+  principle?: Principle;
+  companies: Company[];
+  templates: Record<ChecklistType, EffectiveChecklistTemplate>;
+}) {
   return (
     <section className="rounded-lg border border-border bg-card p-6">
       <div className="flex items-center gap-2">
@@ -141,20 +155,37 @@ function ChecklistPanel({ principle, companies }: { principle?: Principle; compa
 
       <div className="mt-5 space-y-5">
         {checklistTypes.map((type) => (
-          <ChecklistForm key={type.value} type={type.value as ChecklistType} companies={companies} />
+          <ChecklistForm
+            key={type.value}
+            type={type.value as ChecklistType}
+            companies={companies}
+            template={templates[type.value as ChecklistType]}
+          />
         ))}
       </div>
     </section>
   );
 }
 
-function ChecklistForm({ type, companies }: { type: ChecklistType; companies: Company[] }) {
-  const template = checklistTemplates[type];
+function ChecklistForm({
+  type,
+  companies,
+  template
+}: {
+  type: ChecklistType;
+  companies: Company[];
+  template: EffectiveChecklistTemplate;
+}) {
   const typeMeta = checklistTypes.find((item) => item.value === type);
 
   return (
     <details className="rounded-lg border border-border bg-background p-4" open={type === "buy"}>
-      <summary className="cursor-pointer text-sm font-semibold">{typeMeta?.label ?? type}</summary>
+      <summary className="cursor-pointer text-sm font-semibold">
+        {typeMeta?.label ?? type}
+        <span className="ml-2 text-xs text-muted-foreground">
+          {template.isCustom ? "自定义模板" : "默认模板"} / {template.items.length} 项
+        </span>
+      </summary>
       <form action={saveChecklistRun} className="mt-4 space-y-4">
         <input type="hidden" name="checklistType" value={type} />
         <label className="block">
@@ -173,7 +204,7 @@ function ChecklistForm({ type, companies }: { type: ChecklistType; companies: Co
         </label>
 
         <div className="space-y-3">
-          {template.map((item) => (
+          {template.items.map((item) => (
             <ChecklistItem key={item.id} item={item} />
           ))}
         </div>
@@ -189,6 +220,99 @@ function ChecklistForm({ type, companies }: { type: ChecklistType; companies: Co
         >
           <CheckCircle2 className="h-4 w-4" aria-hidden />
           保存检查和决策记录
+        </PendingButton>
+      </form>
+    </details>
+  );
+}
+
+function ChecklistTemplateEditor({
+  templates
+}: {
+  templates: Record<ChecklistType, EffectiveChecklistTemplate>;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <ClipboardCheck className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">自定义检查清单</h2>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        修改模板后，新的检查会使用自定义项；历史检查记录保留当时保存的项目，不会被改写。
+      </p>
+
+      <div className="mt-5 grid gap-5 xl:grid-cols-3">
+        {checklistTypes.map((type) => (
+          <ChecklistTemplateForm
+            key={type.value}
+            type={type.value as ChecklistType}
+            template={templates[type.value as ChecklistType]}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ChecklistTemplateForm({
+  type,
+  template
+}: {
+  type: ChecklistType;
+  template: EffectiveChecklistTemplate;
+}) {
+  const meta = checklistTypes.find((item) => item.value === type);
+  const rows = Array.from({ length: 8 }, (_, index) => template.items[index]);
+
+  return (
+    <details className="rounded-lg border border-border bg-background p-4" open={type === "buy"}>
+      <summary className="cursor-pointer text-sm font-semibold">
+        {meta?.label ?? type}
+        <span className="ml-2 text-xs text-muted-foreground">
+          {template.isCustom ? "已自定义" : "默认"}
+        </span>
+      </summary>
+      <form action={saveChecklistTemplate} className="mt-4 space-y-4">
+        <input type="hidden" name="checklistType" value={type} />
+        <Field label="模板名称" name="title" defaultValue={template.title} />
+
+        <div className="space-y-3">
+          {rows.map((item, index) => (
+            <div key={`${type}-${index}`} className="rounded-md border border-border bg-card p-3">
+              <div className="grid gap-3 md:grid-cols-[1fr_120px]">
+                <label className="block">
+                  <span className="text-xs font-semibold text-primary">检查问题 {index + 1}</span>
+                  <input
+                    name={`itemText.${index}`}
+                    defaultValue={item?.text ?? ""}
+                    placeholder="留空则不保存这一项"
+                    className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+                  />
+                </label>
+                <label className="block">
+                  <span className="text-xs font-semibold text-primary">分类</span>
+                  <input
+                    name={`itemCategory.${index}`}
+                    defaultValue={item?.category ?? ""}
+                    placeholder="通用"
+                    className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
+                  />
+                </label>
+              </div>
+              <label className="mt-3 inline-flex items-center gap-2 text-sm text-muted-foreground">
+                <input name={`itemRequired.${index}`} type="checkbox" defaultChecked={item?.required ?? false} />
+                关键项
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <PendingButton
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+          pendingChildren="保存中..."
+        >
+          <CheckCircle2 className="h-4 w-4" aria-hidden />
+          保存模板
         </PendingButton>
       </form>
     </details>

--- a/src/db/migrations/0007_naive_warbound.sql
+++ b/src/db/migrations/0007_naive_warbound.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `custom_checklist_templates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`checklist_type` text NOT NULL,
+	`title` text NOT NULL,
+	`items_json` text DEFAULT '[]' NOT NULL,
+	`active` integer DEFAULT true NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);

--- a/src/db/migrations/meta/0007_snapshot.json
+++ b/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1262 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fe3cdff8-34d4-41b3-aea6-24dbdd3d6abf",
+  "prevId": "1c20c6a9-4656-48ee-a4ac-8f2d4e8bd3c4",
+  "tables": {
+    "ai_conversations": {
+      "name": "ai_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_conversations_provider_id_model_providers_id_fk": {
+          "name": "ai_conversations_provider_id_model_providers_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_messages": {
+      "name": "ai_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_messages_conversation_id_ai_conversations_id_fk": {
+          "name": "ai_messages_conversation_id_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checklist_runs": {
+      "name": "checklist_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_type": {
+          "name": "checklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "final_judgment": {
+          "name": "final_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_runs_company_id_companies_id_fk": {
+          "name": "checklist_runs_company_id_companies_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "checklist_runs_principle_id_investment_principles_id_fk": {
+          "name": "checklist_runs_principle_id_investment_principles_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_code": {
+          "name": "stock_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_name": {
+          "name": "stock_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "watch_status": {
+          "name": "watch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'watching'"
+        },
+        "valuation_status": {
+          "name": "valuation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "in_circle": {
+          "name": "in_circle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "thesis": {
+          "name": "thesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "key_risks": {
+          "name": "key_risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_checklist_templates": {
+      "name": "custom_checklist_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_type": {
+          "name": "checklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decisions": {
+      "name": "decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checklist_run_id": {
+          "name": "checklist_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_type": {
+          "name": "decision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "final_user_judgment": {
+          "name": "final_user_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_assumptions": {
+          "name": "key_assumptions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risks": {
+          "name": "risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "opponent_summary": {
+          "name": "opponent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "decision_date": {
+          "name": "decision_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "decisions_company_id_companies_id_fk": {
+          "name": "decisions_company_id_companies_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_checklist_run_id_checklist_runs_id_fk": {
+          "name": "decisions_checklist_run_id_checklist_runs_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "checklist_runs",
+          "columnsFrom": [
+            "checklist_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_principle_id_investment_principles_id_fk": {
+          "name": "decisions_principle_id_investment_principles_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "investment_principles": {
+      "name": "investment_principles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'我的 A 股价值投资原则'"
+        },
+        "circle_of_competence": {
+          "name": "circle_of_competence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "excluded_industries": {
+          "name": "excluded_industries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_financial_quality": {
+          "name": "minimum_financial_quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_margin_of_safety": {
+          "name": "minimum_margin_of_safety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_rules": {
+          "name": "position_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "buy_rules": {
+          "name": "buy_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sell_rules": {
+          "name": "sell_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_nothing_rules": {
+          "name": "do_nothing_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risk_rules": {
+          "name": "risk_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_nodes": {
+      "name": "knowledge_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_configs_provider_id_model_providers_id_fk": {
+          "name": "model_configs_provider_id_model_providers_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_providers": {
+      "name": "model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_openai_compatible": {
+          "name": "is_openai_compatible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_insecure_tls": {
+          "name": "allow_insecure_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_name": {
+          "name": "default_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_temperature": {
+          "name": "default_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "max_context_tokens": {
+          "name": "max_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8000
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_tested'"
+        },
+        "last_test_message": {
+          "name": "last_test_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_type": {
+          "name": "review_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'post_decision'"
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "what_happened": {
+          "name": "what_happened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assumptions_validated": {
+          "name": "assumptions_validated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assumptions_failed": {
+          "name": "assumptions_failed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lessons": {
+          "name": "lessons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "principle_changes_needed": {
+          "name": "principle_changes_needed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_decision_id_decisions_id_fk": {
+          "name": "reviews_decision_id_decisions_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_company_id_companies_id_fk": {
+          "name": "reviews_company_id_companies_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "valuations": {
+      "name": "valuations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_type": {
+          "name": "template_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "valuation_date": {
+          "name": "valuation_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shares_outstanding": {
+          "name": "shares_outstanding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CNY'"
+        },
+        "scenario_bear_json": {
+          "name": "scenario_bear_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_base_json": {
+          "name": "scenario_base_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_bull_json": {
+          "name": "scenario_bull_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "valuations_company_id_companies_id_fk": {
+          "name": "valuations_company_id_companies_id_fk",
+          "tableFrom": "valuations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777706205950,
       "tag": "0006_amazing_husk",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1777727487060,
+      "tag": "0007_naive_warbound",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -102,6 +102,16 @@ export const investmentPrinciples = sqliteTable("investment_principles", {
   updatedAt: text("updated_at").notNull()
 });
 
+export const customChecklistTemplates = sqliteTable("custom_checklist_templates", {
+  id: text("id").primaryKey(),
+  checklistType: text("checklist_type").notNull(),
+  title: text("title").notNull(),
+  itemsJson: text("items_json").notNull().default("[]"),
+  active: integer("active", { mode: "boolean" }).notNull().default(true),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
 export const checklistRuns = sqliteTable("checklist_runs", {
   id: text("id").primaryKey(),
   checklistType: text("checklist_type").notNull(),

--- a/src/lib/investment-system/constants.ts
+++ b/src/lib/investment-system/constants.ts
@@ -20,6 +20,14 @@ export type ChecklistTemplateItem = {
   required: boolean;
 };
 
+export type EffectiveChecklistTemplate = {
+  type: ChecklistType;
+  title: string;
+  items: ChecklistTemplateItem[];
+  isCustom: boolean;
+  updatedAt?: string;
+};
+
 export const checklistTemplates: Record<ChecklistType, ChecklistTemplateItem[]> = {
   buy: [
     { id: "circle", text: "公司是否在我的能力圈内，且我能解释它靠什么赚钱？", category: "能力圈", required: true },
@@ -44,6 +52,40 @@ export const checklistTemplates: Record<ChecklistType, ChecklistTemplateItem[]> 
     { id: "next_action", text: "是否写清下一步观察事项、触发条件或复查时间？", category: "下一步", required: true }
   ]
 };
+
+export function getDefaultChecklistTemplate(type: ChecklistType): EffectiveChecklistTemplate {
+  const meta = checklistTypes.find((item) => item.value === type);
+
+  return {
+    type,
+    title: meta?.label ?? type,
+    items: checklistTemplates[type],
+    isCustom: false
+  };
+}
+
+export function parseChecklistTemplateItems(value: string, type: ChecklistType) {
+  try {
+    const parsed = JSON.parse(value);
+
+    if (!Array.isArray(parsed)) {
+      return checklistTemplates[type];
+    }
+
+    const items = parsed
+      .map((item, index) => ({
+        id: typeof item.id === "string" && item.id.trim() ? item.id : `${type}_${index + 1}`,
+        text: typeof item.text === "string" ? item.text.trim() : "",
+        category: typeof item.category === "string" && item.category.trim() ? item.category.trim() : "通用",
+        required: Boolean(item.required)
+      }))
+      .filter((item) => item.text);
+
+    return items.length > 0 ? items : checklistTemplates[type];
+  } catch {
+    return checklistTemplates[type];
+  }
+}
 
 export function labelFor<T extends { value: string; label: string }>(options: T[], value: string) {
   return options.find((option) => option.value === value)?.label ?? value;

--- a/src/lib/investment-system/queries.ts
+++ b/src/lib/investment-system/queries.ts
@@ -1,6 +1,13 @@
 import { desc, eq } from "drizzle-orm";
 import { db } from "@/db/client";
-import { checklistRuns, companies, decisions, investmentPrinciples } from "@/db/schema";
+import { checklistRuns, companies, customChecklistTemplates, decisions, investmentPrinciples } from "@/db/schema";
+import {
+  checklistTypes,
+  getDefaultChecklistTemplate,
+  parseChecklistTemplateItems,
+  type ChecklistType,
+  type EffectiveChecklistTemplate
+} from "@/lib/investment-system/constants";
 
 export async function getActiveInvestmentPrinciple() {
   const [principle] = await db
@@ -14,7 +21,7 @@ export async function getActiveInvestmentPrinciple() {
 }
 
 export async function getSystemPageData() {
-  const [principle, companyRows, runRows, decisionRows] = await Promise.all([
+  const [principle, companyRows, runRows, decisionRows, templates] = await Promise.all([
     getActiveInvestmentPrinciple(),
     db.select().from(companies).orderBy(desc(companies.updatedAt)),
     db
@@ -34,13 +41,46 @@ export async function getSystemPageData() {
       .from(decisions)
       .leftJoin(companies, eq(decisions.companyId, companies.id))
       .orderBy(desc(decisions.createdAt))
-      .limit(6)
+      .limit(6),
+    getEffectiveChecklistTemplates()
   ]);
 
   return {
     principle,
     companies: companyRows,
     recentRuns: runRows,
-    recentDecisions: decisionRows
+    recentDecisions: decisionRows,
+    checklistTemplates: templates
   };
+}
+
+export async function getEffectiveChecklistTemplates(): Promise<Record<ChecklistType, EffectiveChecklistTemplate>> {
+  const rows = await db
+    .select()
+    .from(customChecklistTemplates)
+    .where(eq(customChecklistTemplates.active, true))
+    .orderBy(desc(customChecklistTemplates.updatedAt));
+
+  return checklistTypes.reduce((templates, item) => {
+    const type = item.value as ChecklistType;
+    const custom = rows.find((row) => row.checklistType === type);
+
+    templates[type] = custom
+      ? {
+          type,
+          title: custom.title,
+          items: parseChecklistTemplateItems(custom.itemsJson, type),
+          isCustom: true,
+          updatedAt: custom.updatedAt
+        }
+      : getDefaultChecklistTemplate(type);
+
+    return templates;
+  }, {} as Record<ChecklistType, EffectiveChecklistTemplate>);
+}
+
+export async function getEffectiveChecklistTemplate(type: ChecklistType) {
+  const templates = await getEffectiveChecklistTemplates();
+
+  return templates[type];
 }


### PR DESCRIPTION
## 关联 Issue\n\nCloses #25\n\n## 改动摘要\n\n- 新增自定义检查清单模板表。\n- 投资系统页新增自定义检查清单编辑区。\n- 支持编辑买入、卖出、不操作三类模板。\n- 每类模板第一版最多 8 个检查项，可设置问题、分类和是否关键项。\n- 后续运行检查会读取有效模板，历史检查记录保留保存时的项目。\n\n## 主要文件\n\n- app/system/page.tsx\n- app/system/actions.ts\n- src/lib/investment-system/constants.ts\n- src/lib/investment-system/queries.ts\n- src/db/schema.ts\n- src/db/migrations/0007_naive_warbound.sql\n\n## 验证\n\n- [x] npm run db:generate\n- [x] npm run db:migrate\n- [x] npm run typecheck\n- [x] npm run build\n- [x] 重启 next dev 后验证 /system 返回 200\n- [x] 验证 /_next/static/css/app/layout.css 返回 200\n- [x] 页面显示自定义检查清单和保存模板入口\n\n## 数据库迁移\n\n新增 custom_checklist_templates 表，用于保存用户自定义的检查清单模板。历史 checklist_runs 仍保留 items_json，不受模板变更影响。\n\n## 风险\n\n第一版不做拖拽排序和动态增删，使用固定 8 行编辑；后续可以增强为更精细的模板编辑器。\n\n## 回退方案\n\n回退本 PR 后系统恢复默认固定清单；新增模板表不会影响历史检查记录。