### PR TITLE
feat: add valuation template guidance

### DIFF
--- a/app/valuations/actions.ts
+++ b/app/valuations/actions.ts
@@ -17,8 +17,8 @@ const valuationSchema = z.object({
   templateType: z.enum(["financial", "cyclical", "consumer", "manufacturing"]),
   title: z.string().trim().min(1, "请填写估值标题。"),
   valuationDate: z.string().trim().min(1, "请选择估值日期。"),
-  currentPrice: z.coerce.number().nonnegative("当前价格不能为负。"),
-  sharesOutstanding: z.coerce.number().positive("总股本必须大于 0。"),
+  currentPrice: z.coerce.number().nonnegative("当前价格不能为负，请按元/股填写。"),
+  sharesOutstanding: z.coerce.number().positive("请填写总股本（亿股），且必须大于 0。例如：76.63。"),
   userNotes: z.string().trim().default("")
 });
 
@@ -61,7 +61,9 @@ export async function saveValuation(formData: FormData) {
   const invalidScenario = scenarioInputs.find((scenario) => scenario.basisAmount <= 0);
 
   if (invalidScenario) {
-    statusRedirect("error", "三个情景都需要填写有效的估值起点。");
+    const scenarioLabel = scenarios.find((scenario) => scenario.value === invalidScenario.name)?.label ?? invalidScenario.name;
+    const template = getTemplate(parsed.data.templateType);
+    statusRedirect("error", `请填写${scenarioLabel}情景的${template.basisLabel}，且必须大于 0。`);
   }
 
   const result = calculateValuation({

--- a/app/valuations/page.tsx
+++ b/app/valuations/page.tsx
@@ -55,6 +55,8 @@ export default async function ValuationsPage({ searchParams }: ValuationsPagePro
         <StatusBanner status={params.status === "success" ? "success" : "error"} message={params.message} />
       ) : null}
 
+      <TemplateSelectionGuide />
+
       <section className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <section className="rounded-lg border border-border bg-card p-6">
           <div className="flex items-center gap-2">
@@ -116,8 +118,8 @@ function ValuationForm({
           </label>
           <Field label="估值标题" name="title" defaultValue={`${template.label}估值`} />
           <Field label="估值日期" name="valuationDate" type="date" defaultValue={new Date().toISOString().slice(0, 10)} />
-          <Field label="当前价格（元/股）" name="currentPrice" type="number" step="0.01" />
-          <Field label="总股本（亿股）" name="sharesOutstanding" type="number" step="0.0001" />
+          <Field label="当前价格（元/股）" name="currentPrice" type="number" step="0.01" placeholder="例如：72.50" />
+          <Field label="总股本（亿股）" name="sharesOutstanding" type="number" step="0.0001" placeholder="例如：76.63" />
         </div>
 
         <div className="grid gap-4">
@@ -142,6 +144,32 @@ function ValuationForm({
         </PendingButton>
       </form>
     </details>
+  );
+}
+
+function TemplateSelectionGuide() {
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        title="模板选择指南"
+        description="先判断公司靠什么创造价值，再选主模板；复杂公司可以用第二个模板交叉验证。这里帮助你选工具，不给买卖结论。"
+      />
+      <div className="grid gap-4 lg:grid-cols-4">
+        {valuationTemplates.map((template) => (
+          <article key={template.value} className="rounded-lg border border-border bg-card p-4">
+            <div className="text-sm font-semibold">{template.label}</div>
+            <p className="mt-1 text-xs text-primary">{template.method}</p>
+            <InfoLine title="适合" value={template.fitFor} />
+            <InfoLine title="慎用" value={template.avoidFor} />
+            <InfoLine title="例子" value={template.examples} />
+          </article>
+        ))}
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 text-sm leading-6">
+        <span className="font-semibold">美的集团这类成熟消费制造公司：</span>
+        优先用制造业模板看自由现金流、资本开支和营运资本，再用消费股模板用利润增长和 PE 做交叉验证。
+      </div>
+    </section>
   );
 }
 
@@ -241,6 +269,15 @@ function RecentValuations({
         )}
       </div>
     </section>
+  );
+}
+
+function InfoLine({ title, value }: { title: string; value: string }) {
+  return (
+    <p className="mt-3 text-sm leading-6 text-muted-foreground">
+      <span className="font-semibold text-foreground">{title}：</span>
+      {value}
+    </p>
   );
 }
 

--- a/src/lib/valuations/constants.ts
+++ b/src/lib/valuations/constants.ts
@@ -7,7 +7,10 @@ export const valuationTemplates = [
     basisHint: "元/股，例如银行常用每股净资产作为估值起点。",
     multipleLabel: "PB 倍数",
     growthLabel: "ROE 或利润变化",
-    focus: "关注 ROE 可持续性、资产质量、不良率、拨备和资本充足。"
+    focus: "关注 ROE 可持续性、资产质量、不良率、拨备和资本充足。",
+    fitFor: "银行、保险、券商等资产负债表驱动的金融机构。",
+    avoidFor: "不适合用来估值制造业、消费品、资源品和轻资产成长公司。",
+    examples: "招商银行、平安银行、中国平安、中信证券"
   },
   {
     value: "cyclical",
@@ -17,7 +20,10 @@ export const valuationTemplates = [
     basisHint: "亿元，尽量使用跨周期利润中枢，而不是景气顶部利润。",
     multipleLabel: "中枢 PE 倍数",
     growthLabel: "利润修正",
-    focus: "关注当前景气位置、商品价格、负债和资本开支。"
+    focus: "关注当前景气位置、商品价格、负债和资本开支。",
+    fitFor: "利润跟商品价格、产能周期或行业景气强相关的公司。",
+    avoidFor: "不要直接拿景气顶部利润做估值起点，也不要用于需求稳定的消费龙头。",
+    examples: "中国神华、宝钢股份、万华化学、紫金矿业"
   },
   {
     value: "consumer",
@@ -27,7 +33,10 @@ export const valuationTemplates = [
     basisHint: "亿元，使用最近一年归母净利润或更保守的正常化利润。",
     multipleLabel: "合理 PE 倍数",
     growthLabel: "未来三年年化利润增长",
-    focus: "关注增长、ROE、现金流、渠道库存、提价能力和品牌强度。"
+    focus: "关注增长、ROE、现金流、渠道库存、提价能力和品牌强度。",
+    fitFor: "品牌、渠道、复购和利润稳定性较强的消费公司。",
+    avoidFor: "不适合资本开支很重、现金流波动大或利润明显周期化的公司作为唯一模板。",
+    examples: "贵州茅台、伊利股份、海天味业、美的集团（交叉验证）"
   },
   {
     value: "manufacturing",
@@ -37,7 +46,10 @@ export const valuationTemplates = [
     basisHint: "亿元，尽量使用可持续自由现金流，而不是单年高点。",
     multipleLabel: "备用 PE 倍数",
     growthLabel: "未来五年 FCF 增长",
-    focus: "关注资本开支、研发、存货、应收、客户集中和竞争格局。"
+    focus: "关注资本开支、研发、存货、应收、客户集中和竞争格局。",
+    fitFor: "成熟制造、消费制造、现金流可估、资本开支和营运资本需要跟踪的公司。",
+    avoidFor: "不适合金融机构；高波动周期股需要先用周期中枢利润校验。",
+    examples: "美的集团、格力电器、海尔智家、三一重工"
   }
 ] as const;
 


### PR DESCRIPTION
## 关联 Issue

Closes #29

## 改动摘要

- 在估值页新增模板选择指南，说明四类模板的适用对象、慎用场景和 A 股示例。
- 增加美的集团这类成熟消费制造公司的模板选择提示。
- 为当前价格、总股本字段补充填写示例。
- 优化总股本和情景估值起点的服务端校验文案。

## 主要文件

- app/valuations/page.tsx
- app/valuations/actions.ts
- src/lib/valuations/constants.ts

## 验证

- [x] npm run typecheck
- [x] npm run build
- [x] curl /valuations returns 200
- [x] CSS asset from rendered page returns 200
- [x] Rendered /valuations contains 模板选择指南、美的集团提示、总股本示例

## 截图 / 说明

页面顶部新增模板选择指南，创建估值表单仍在其下方，估值计算公式和历史记录展示不变。

## 数据库迁移

无。

## 风险

页面顶部信息密度增加。

## 回退方案

回退本 PR 即恢复原估值页。