### PR TITLE
持久化学习进度与训练结果

### DIFF
--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -9,9 +9,11 @@ import {
   decisions,
   investmentPrinciples,
   knowledgeNodes,
+  learningProgress,
   modelConfigs,
   modelProviders,
   reviews,
+  trainingResults,
   valuations
 } from "@/db/schema";
 
@@ -22,6 +24,8 @@ export async function GET() {
     conversationRows,
     messageRows,
     knowledgeRows,
+    learningProgressRows,
+    trainingResultRows,
     companyRows,
     principleRows,
     checklistTemplateRows,
@@ -52,6 +56,8 @@ export async function GET() {
     db.select().from(aiConversations),
     db.select().from(aiMessages),
     db.select().from(knowledgeNodes),
+    db.select().from(learningProgress),
+    db.select().from(trainingResults),
     db.select().from(companies),
     db.select().from(investmentPrinciples),
     db.select().from(customChecklistTemplates),
@@ -73,6 +79,8 @@ export async function GET() {
       aiConversations: conversationRows,
       aiMessages: messageRows,
       knowledgeNodes: knowledgeRows,
+      learningProgress: learningProgressRows,
+      trainingResults: trainingResultRows,
       companies: companyRows,
       investmentPrinciples: principleRows,
       customChecklistTemplates: checklistTemplateRows,

--- a/app/learn/[nodeId]/page.tsx
+++ b/app/learn/[nodeId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { ArrowLeft, Bot, CheckCircle2 } from "lucide-react";
 import { BookInsightPanel } from "@/components/learning/book-insight-panel";
 import { CoreIdeaPanel } from "@/components/learning/core-idea-panel";
+import { PendingButton } from "@/components/ui/pending-button";
 import { getBookInsight } from "@/lib/learning/book-insights";
 import {
   getKnowledgeNode,
@@ -10,6 +11,9 @@ import {
   knowledgeNodes,
   nodeTypeLabels
 } from "@/lib/learning/nodes";
+import { getLearningProgressByNodeId } from "@/lib/learning/progress";
+import { learningStatusLabels, type LearningStatus } from "@/lib/learning/status";
+import { updateLearningStatus } from "../actions";
 
 type NodeDetailPageProps = {
   params: Promise<{
@@ -17,11 +21,7 @@ type NodeDetailPageProps = {
   }>;
 };
 
-export function generateStaticParams() {
-  return knowledgeNodes.map((node) => ({
-    nodeId: node.id
-  }));
-}
+export const dynamic = "force-dynamic";
 
 export default async function NodeDetailPage({ params }: NodeDetailPageProps) {
   const { nodeId } = await params;
@@ -33,6 +33,8 @@ export default async function NodeDetailPage({ params }: NodeDetailPageProps) {
 
   const relatedNodes = getRelatedNodes(node);
   const bookInsight = node.type === "book" ? getBookInsight(node.id) : null;
+  const progressByNodeId = await getLearningProgressByNodeId();
+  const status = getLearningStatus(progressByNodeId[node.id]?.status);
   const mentorDraft = `请用通俗语言解释「${node.title}」，并结合 A 股价值投资实践举一个不构成投资建议的例子。`;
 
   return (
@@ -77,6 +79,8 @@ export default async function NodeDetailPage({ params }: NodeDetailPageProps) {
         </div>
 
         <aside className="space-y-6">
+          <LearningStatusPanel nodeId={node.id} status={status} />
+
           <div className="rounded-lg border border-border bg-card p-5">
             <h2 className="font-semibold">经典书籍</h2>
             <div className="mt-3 space-y-2">
@@ -106,6 +110,49 @@ export default async function NodeDetailPage({ params }: NodeDetailPageProps) {
         </aside>
       </section>
     </main>
+  );
+}
+
+function getLearningStatus(status?: string): LearningStatus {
+  if (status === "completed" || status === "in_progress") {
+    return status;
+  }
+
+  return "not_started";
+}
+
+function LearningStatusPanel({ nodeId, status }: { nodeId: string; status: LearningStatus }) {
+  const actions: Array<{ status: LearningStatus; label: string; pending: string }> = [
+    { status: "in_progress", label: "标记学习中", pending: "保存中" },
+    { status: "completed", label: "标记已学完", pending: "保存中" },
+    { status: "not_started", label: "重置状态", pending: "重置中" }
+  ];
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-5">
+      <h2 className="font-semibold">学习状态</h2>
+      <div className="mt-3 rounded-md border border-border bg-background px-3 py-2 text-sm">
+        当前：<span className="font-semibold text-primary">{learningStatusLabels[status]}</span>
+      </div>
+      <div className="mt-3 grid gap-2">
+        {actions.map((item) => (
+          <form key={item.status} action={updateLearningStatus}>
+            <input type="hidden" name="nodeId" value={nodeId} />
+            <input type="hidden" name="status" value={item.status} />
+            <PendingButton
+              pendingChildren={item.pending}
+              disabled={status === item.status}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-semibold transition hover:bg-muted disabled:opacity-50"
+            >
+              {item.label}
+            </PendingButton>
+          </form>
+        ))}
+      </div>
+      <p className="mt-3 text-xs leading-5 text-muted-foreground">
+        状态会保存到本地数据库，用来计算学习地图进度和后续复习建议。
+      </p>
+    </div>
   );
 }
 

--- a/app/learn/actions.ts
+++ b/app/learn/actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { learningProgress } from "@/db/schema";
+import type { LearningStatus } from "@/lib/learning/status";
+
+const learningStatusSchema = z.enum(["not_started", "in_progress", "completed"]);
+
+const formSchema = z.object({
+  nodeId: z.string().min(1),
+  status: learningStatusSchema
+});
+
+function now() {
+  return new Date().toISOString();
+}
+
+export async function updateLearningStatus(formData: FormData) {
+  const parsed = formSchema.safeParse({
+    nodeId: formData.get("nodeId"),
+    status: formData.get("status")
+  });
+
+  if (!parsed.success) {
+    return;
+  }
+
+  await setLearningStatus(parsed.data.nodeId, parsed.data.status);
+}
+
+export async function setLearningStatus(nodeId: string, status: LearningStatus) {
+  const updatedAt = now();
+  const completedAt = status === "completed" ? updatedAt : null;
+  const masteryScore = status === "completed" ? 100 : status === "in_progress" ? 40 : 0;
+
+  await db
+    .insert(learningProgress)
+    .values({
+      id: nodeId,
+      nodeId,
+      status,
+      masteryScore,
+      completedAt,
+      createdAt: updatedAt,
+      updatedAt
+    })
+    .onConflictDoUpdate({
+      target: learningProgress.id,
+      set: {
+        status,
+        masteryScore,
+        completedAt,
+        updatedAt
+      }
+    });
+
+  revalidatePath("/");
+  revalidatePath("/learn");
+  revalidatePath(`/learn/${nodeId}`);
+}
+
+export async function resetLearningStatus(formData: FormData) {
+  const nodeId = String(formData.get("nodeId") ?? "");
+
+  if (!nodeId) {
+    return;
+  }
+
+  await db.delete(learningProgress).where(eq(learningProgress.id, nodeId));
+
+  revalidatePath("/");
+  revalidatePath("/learn");
+  revalidatePath(`/learn/${nodeId}`);
+}

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,6 +1,11 @@
 import { LearningMap } from "@/components/learning/learning-map";
 import { knowledgeNodes } from "@/lib/learning/nodes";
+import { getLearningProgressByNodeId } from "@/lib/learning/progress";
 
-export default function LearnPage() {
-  return <LearningMap nodes={knowledgeNodes} />;
+export const dynamic = "force-dynamic";
+
+export default async function LearnPage() {
+  const progressByNodeId = await getLearningProgressByNodeId();
+
+  return <LearningMap nodes={knowledgeNodes} progressByNodeId={progressByNodeId} />;
 }

--- a/app/settings/actions.ts
+++ b/app/settings/actions.ts
@@ -14,9 +14,11 @@ import {
   decisions,
   investmentPrinciples,
   knowledgeNodes,
+  learningProgress,
   modelConfigs,
   modelProviders,
   reviews,
+  trainingResults,
   valuations
 } from "@/db/schema";
 import { encryptSecret } from "@/lib/encryption/crypto";
@@ -115,6 +117,28 @@ const importPayloadSchema = z.object({
       orderIndex: integerValue,
       createdAt: stringValue,
       updatedAt: stringValue
+    })).default([]),
+    learningProgress: z.array(z.object({
+      id: z.string().min(1),
+      nodeId: z.string().min(1),
+      status: stringValue.default("not_started"),
+      masteryScore: integerValue,
+      notes: stringValue,
+      completedAt: optionalStringValue,
+      createdAt: stringValue,
+      updatedAt: stringValue
+    })).default([]),
+    trainingResults: z.array(z.object({
+      id: z.string().min(1),
+      questionSetJson: stringValue.default("[]"),
+      answersJson: stringValue.default("{}"),
+      weakTopicsJson: stringValue.default("[]"),
+      answeredCount: integerValue,
+      correctCount: integerValue,
+      score: integerValue,
+      reviewAdvice: stringValue,
+      examinerPrompt: stringValue,
+      createdAt: stringValue
     })).default([]),
     companies: z.array(z.object({
       id: z.string().min(1),
@@ -478,6 +502,8 @@ export async function importBackup(formData: FormData) {
     aiConversations: 0,
     aiMessages: 0,
     knowledgeNodes: 0,
+    learningProgress: 0,
+    trainingResults: 0,
     companies: 0,
     investmentPrinciples: 0,
     customChecklistTemplates: 0,
@@ -517,6 +543,8 @@ export async function importBackup(formData: FormData) {
   importedCounts.aiConversations = await upsertRows(aiConversations, data.aiConversations);
   importedCounts.aiMessages = await upsertRows(aiMessages, data.aiMessages);
   importedCounts.knowledgeNodes = await upsertRows(knowledgeNodes, data.knowledgeNodes);
+  importedCounts.learningProgress = await upsertRows(learningProgress, data.learningProgress);
+  importedCounts.trainingResults = await upsertRows(trainingResults, data.trainingResults);
   importedCounts.companies = await upsertRows(companies, data.companies);
   importedCounts.investmentPrinciples = await upsertRows(investmentPrinciples, data.investmentPrinciples);
   importedCounts.customChecklistTemplates = await upsertRows(customChecklistTemplates, data.customChecklistTemplates);
@@ -526,6 +554,8 @@ export async function importBackup(formData: FormData) {
   importedCounts.reviews = await upsertRows(reviews, data.reviews);
 
   revalidatePath("/");
+  revalidatePath("/learn");
+  revalidatePath("/training");
   revalidatePath("/settings");
   revalidatePath("/watchlist");
   revalidatePath("/valuations");
@@ -564,6 +594,8 @@ function formatImportSummary(counts: Record<string, number>) {
     aiConversations: "AI 对话",
     aiMessages: "AI 消息",
     knowledgeNodes: "知识节点",
+    learningProgress: "学习进度",
+    trainingResults: "训练结果",
     companies: "观察池公司",
     investmentPrinciples: "投资原则",
     customChecklistTemplates: "自定义清单",

--- a/app/training/actions.ts
+++ b/app/training/actions.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { trainingResults } from "@/db/schema";
+
+const trainingResultSchema = z.object({
+  questionSet: z.array(z.string().min(1)).min(1),
+  answers: z.record(z.string().min(1), z.string().min(1)),
+  weakTopics: z.array(z.string()).default([]),
+  answeredCount: z.number().int().min(0),
+  correctCount: z.number().int().min(0),
+  score: z.number().int().min(0).max(100),
+  reviewAdvice: z.string().default(""),
+  examinerPrompt: z.string().default("")
+});
+
+export type TrainingResultInput = z.infer<typeof trainingResultSchema>;
+
+export async function saveTrainingResult(input: TrainingResultInput) {
+  const parsed = trainingResultSchema.safeParse(input);
+
+  if (!parsed.success || parsed.data.answeredCount === 0) {
+    return;
+  }
+
+  await db.insert(trainingResults).values({
+    id: crypto.randomUUID(),
+    questionSetJson: JSON.stringify(parsed.data.questionSet),
+    answersJson: JSON.stringify(parsed.data.answers),
+    weakTopicsJson: JSON.stringify(parsed.data.weakTopics),
+    answeredCount: parsed.data.answeredCount,
+    correctCount: parsed.data.correctCount,
+    score: parsed.data.score,
+    reviewAdvice: parsed.data.reviewAdvice,
+    examinerPrompt: parsed.data.examinerPrompt,
+    createdAt: new Date().toISOString()
+  });
+
+  revalidatePath("/training");
+}

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -1,6 +1,12 @@
 import { TrainingArena } from "@/components/training/training-arena";
+import { getRecentTrainingResults } from "@/lib/learning/progress";
 import { trainingQuestions } from "@/lib/training/questions";
+import { saveTrainingResult } from "./actions";
 
-export default function TrainingPage() {
-  return <TrainingArena questions={trainingQuestions} />;
+export const dynamic = "force-dynamic";
+
+export default async function TrainingPage() {
+  const recentResults = await getRecentTrainingResults();
+
+  return <TrainingArena questions={trainingQuestions} recentResults={recentResults} onSaveResult={saveTrainingResult} />;
 }

--- a/src/components/learning/learning-map.tsx
+++ b/src/components/learning/learning-map.tsx
@@ -5,9 +5,13 @@ import { useMemo, useState } from "react";
 import { ArrowRight, BookOpen, CheckCircle2, Circle, Map, Milestone } from "lucide-react";
 import type { KnowledgeNode, KnowledgeNodeType } from "@/lib/learning/nodes";
 import { nodeTypeLabels } from "@/lib/learning/nodes";
+import type { LearningProgressRow } from "@/lib/learning/progress";
+import type { LearningStatus } from "@/lib/learning/status";
+import { learningStatusLabels } from "@/lib/learning/status";
 
 type LearningMapProps = {
   nodes: KnowledgeNode[];
+  progressByNodeId: Record<string, LearningProgressRow>;
 };
 
 const filters: Array<{ value: "all" | KnowledgeNodeType; label: string }> = [
@@ -20,7 +24,7 @@ const filters: Array<{ value: "all" | KnowledgeNodeType; label: string }> = [
   { value: "case", label: "A 股案例" }
 ];
 
-export function LearningMap({ nodes }: LearningMapProps) {
+export function LearningMap({ nodes, progressByNodeId }: LearningMapProps) {
   const [activeType, setActiveType] = useState<"all" | KnowledgeNodeType>("all");
   const timelineNodes = nodes.filter((node) => node.type === "timeline");
   const schoolNodes = nodes.filter((node) => node.type === "school");
@@ -28,7 +32,8 @@ export function LearningMap({ nodes }: LearningMapProps) {
     () => (activeType === "all" ? nodes : nodes.filter((node) => node.type === activeType)),
     [activeType, nodes]
   );
-  const learnedCount = 0;
+  const learnedCount = nodes.filter((node) => progressByNodeId[node.id]?.status === "completed").length;
+  const inProgressCount = nodes.filter((node) => progressByNodeId[node.id]?.status === "in_progress").length;
 
   return (
     <div className="space-y-8">
@@ -46,7 +51,7 @@ export function LearningMap({ nodes }: LearningMapProps) {
           <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
             <Metric label="节点" value={nodes.length} />
             <Metric label="已学" value={learnedCount} />
-            <Metric label="案例" value={nodes.filter((node) => node.type === "case").length} />
+            <Metric label="学习中" value={inProgressCount} />
           </div>
         </div>
       </section>
@@ -66,6 +71,7 @@ export function LearningMap({ nodes }: LearningMapProps) {
               >
                 <div className="text-xs font-semibold text-muted-foreground">{node.period}</div>
                 <div className="mt-3 min-h-12 text-sm font-semibold leading-6">{node.title}</div>
+                <StatusBadge status={getNodeStatus(progressByNodeId[node.id])} />
                 <div className="mt-3 flex items-center justify-between">
                   <span className="text-xs text-muted-foreground">0{index + 1}</span>
                   {index < timelineNodes.length - 1 ? (
@@ -95,6 +101,7 @@ export function LearningMap({ nodes }: LearningMapProps) {
               <div className="text-xs font-semibold text-primary">{node.school}</div>
               <h3 className="mt-2 font-semibold">{node.title}</h3>
               <p className="mt-2 line-clamp-3 text-sm leading-6 text-muted-foreground">{node.summary}</p>
+              <StatusBadge status={getNodeStatus(progressByNodeId[node.id])} />
             </Link>
           ))}
         </div>
@@ -125,7 +132,7 @@ export function LearningMap({ nodes }: LearningMapProps) {
         </div>
         <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {filteredNodes.map((node) => (
-            <KnowledgeCard key={node.id} node={node} />
+            <KnowledgeCard key={node.id} node={node} status={getNodeStatus(progressByNodeId[node.id])} />
           ))}
         </div>
       </section>
@@ -133,7 +140,9 @@ export function LearningMap({ nodes }: LearningMapProps) {
   );
 }
 
-function KnowledgeCard({ node }: { node: KnowledgeNode }) {
+function KnowledgeCard({ node, status }: { node: KnowledgeNode; status: LearningStatus }) {
+  const completed = status === "completed";
+
   return (
     <Link
       href={`/learn/${node.id}`}
@@ -144,9 +153,14 @@ function KnowledgeCard({ node }: { node: KnowledgeNode }) {
           <div className="text-xs font-semibold text-primary">{nodeTypeLabels[node.type]}</div>
           <h3 className="mt-2 font-semibold">{node.title}</h3>
         </div>
-        <Circle className="mt-1 h-4 w-4 text-muted-foreground" aria-hidden />
+        {completed ? (
+          <CheckCircle2 className="mt-1 h-4 w-4 text-primary" aria-hidden />
+        ) : (
+          <Circle className="mt-1 h-4 w-4 text-muted-foreground" aria-hidden />
+        )}
       </div>
       <p className="mt-3 line-clamp-3 text-sm leading-6 text-muted-foreground">{node.summary}</p>
+      <StatusBadge status={status} />
       <div className="mt-4 flex flex-wrap gap-2">
         {node.coreIdeas.slice(0, 3).map((idea) => (
           <span key={idea} className="rounded-md border border-border bg-card px-2 py-1 text-xs text-muted-foreground">
@@ -155,6 +169,33 @@ function KnowledgeCard({ node }: { node: KnowledgeNode }) {
         ))}
       </div>
     </Link>
+  );
+}
+
+function getNodeStatus(progress?: LearningProgressRow): LearningStatus {
+  if (progress?.status === "completed" || progress?.status === "in_progress") {
+    return progress.status;
+  }
+
+  return "not_started";
+}
+
+function StatusBadge({ status }: { status: LearningStatus }) {
+  const completed = status === "completed";
+  const inProgress = status === "in_progress";
+
+  return (
+    <span
+      className={`mt-3 inline-flex rounded-md border px-2 py-1 text-xs font-semibold ${
+        completed
+          ? "border-primary bg-muted text-primary"
+          : inProgress
+            ? "border-border bg-card text-foreground"
+            : "border-border bg-card text-muted-foreground"
+      }`}
+    >
+      {learningStatusLabels[status]}
+    </span>
   );
 }
 

--- a/src/components/training/training-arena.tsx
+++ b/src/components/training/training-arena.tsx
@@ -1,13 +1,28 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import { Bot, CheckCircle2, CircleAlert, RotateCcw, Trophy } from "lucide-react";
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Bot, CheckCircle2, CircleAlert, History, RotateCcw, Trophy } from "lucide-react";
 import type { TrainingQuestion, TrainingQuestionType } from "@/lib/training/questions";
 import { questionTypeLabels } from "@/lib/training/questions";
+import type { TrainingResultRow } from "@/lib/learning/progress";
 
 type TrainingArenaProps = {
   questions: TrainingQuestion[];
+  recentResults: TrainingResultRow[];
+  onSaveResult: (input: TrainingResultPayload) => Promise<void>;
+};
+
+type TrainingResultPayload = {
+  questionSet: string[];
+  answers: Record<string, string>;
+  weakTopics: string[];
+  answeredCount: number;
+  correctCount: number;
+  score: number;
+  reviewAdvice: string;
+  examinerPrompt: string;
 };
 
 const filters: Array<{ value: "all" | TrainingQuestionType; label: string }> = [
@@ -17,10 +32,13 @@ const filters: Array<{ value: "all" | TrainingQuestionType; label: string }> = [
   { value: "case", label: "案例题" }
 ];
 
-export function TrainingArena({ questions }: TrainingArenaProps) {
+export function TrainingArena({ questions, recentResults, onSaveResult }: TrainingArenaProps) {
+  const router = useRouter();
   const [activeType, setActiveType] = useState<"all" | TrainingQuestionType>("all");
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [submitted, setSubmitted] = useState(false);
+  const [savedSignature, setSavedSignature] = useState("");
+  const [isSaving, startSaving] = useTransition();
   const visibleQuestions = useMemo(
     () => (activeType === "all" ? questions : questions.filter((question) => question.type === activeType)),
     [activeType, questions]
@@ -50,12 +68,49 @@ export function TrainingArena({ questions }: TrainingArenaProps) {
   function reset() {
     setAnswers({});
     setSubmitted(false);
+    setSavedSignature("");
   }
 
   const weakQuestions = submitted
-    ? questions.filter((question) => answers[question.id] !== question.correctOptionId)
+    ? questions.filter((question) => answers[question.id] && answers[question.id] !== question.correctOptionId)
     : [];
+  const weakTopics = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          questions
+            .filter((question) => answers[question.id] && answers[question.id] !== question.correctOptionId)
+            .map((question) => question.topic)
+        )
+      ),
+    [answers, questions]
+  );
+  const reviewAdvice = getScoreAdvice(result.score);
   const examinerDraft = buildExaminerDraft(questions, answers);
+
+  function submitTraining() {
+    setSubmitted(true);
+
+    const signature = JSON.stringify(answers);
+    if (result.answered === 0 || signature === savedSignature) {
+      return;
+    }
+
+    startSaving(async () => {
+      await onSaveResult({
+        questionSet: questions.map((question) => question.id),
+        answers,
+        weakTopics,
+        answeredCount: result.answered,
+        correctCount: result.correct,
+        score: result.score,
+        reviewAdvice,
+        examinerPrompt: examinerDraft
+      });
+      setSavedSignature(signature);
+      router.refresh();
+    });
+  }
 
   return (
     <main className="space-y-8">
@@ -97,12 +152,12 @@ export function TrainingArena({ questions }: TrainingArenaProps) {
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
-              onClick={() => setSubmitted(true)}
+              onClick={submitTraining}
               disabled={result.answered === 0}
               className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
             >
               <Trophy className="h-4 w-4" aria-hidden />
-              提交测验
+              {isSaving ? "保存中" : "提交测验"}
             </button>
             <button
               type="button"
@@ -141,6 +196,8 @@ export function TrainingArena({ questions }: TrainingArenaProps) {
         </section>
       ) : null}
 
+      <RecentResultsPanel results={recentResults} />
+
       <section className="grid gap-4">
         {visibleQuestions.map((question, index) => (
           <QuestionCard
@@ -155,6 +212,64 @@ export function TrainingArena({ questions }: TrainingArenaProps) {
       </section>
     </main>
   );
+}
+
+function RecentResultsPanel({ results }: { results: TrainingResultRow[] }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="flex items-center gap-2">
+        <History className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">最近训练</h2>
+      </div>
+      {results.length === 0 ? (
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          还没有训练记录。完成一次测验后，这里会保留得分、薄弱主题和复习建议。
+        </p>
+      ) : (
+        <div className="mt-4 grid gap-3">
+          {results.map((result) => {
+            const weakTopics = parseStringArray(result.weakTopicsJson);
+            return (
+              <div key={result.id} className="rounded-lg border border-border bg-background p-4">
+                <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                  <div className="font-semibold">
+                    得分 {result.score}% · 答对 {result.correctCount}/{result.answeredCount}
+                  </div>
+                  <div className="text-xs text-muted-foreground">{formatDateTime(result.createdAt)}</div>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">{result.reviewAdvice}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {(weakTopics.length > 0 ? weakTopics : ["暂无明显薄弱主题"]).map((topic) => (
+                    <span key={topic} className="rounded-md border border-border bg-card px-2 py-1 text-xs text-muted-foreground">
+                      {topic}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function parseStringArray(value: string) {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(new Date(value));
 }
 
 function QuestionCard({

--- a/src/db/migrations/0008_flashy_giant_girl.sql
+++ b/src/db/migrations/0008_flashy_giant_girl.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `learning_progress` (
+	`id` text PRIMARY KEY NOT NULL,
+	`node_id` text NOT NULL,
+	`status` text DEFAULT 'not_started' NOT NULL,
+	`mastery_score` integer DEFAULT 0 NOT NULL,
+	`notes` text DEFAULT '' NOT NULL,
+	`completed_at` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `training_results` (
+	`id` text PRIMARY KEY NOT NULL,
+	`question_set_json` text DEFAULT '[]' NOT NULL,
+	`answers_json` text DEFAULT '{}' NOT NULL,
+	`weak_topics_json` text DEFAULT '[]' NOT NULL,
+	`answered_count` integer DEFAULT 0 NOT NULL,
+	`correct_count` integer DEFAULT 0 NOT NULL,
+	`score` integer DEFAULT 0 NOT NULL,
+	`review_advice` text DEFAULT '' NOT NULL,
+	`examiner_prompt` text DEFAULT '' NOT NULL,
+	`created_at` text NOT NULL
+);

--- a/src/db/migrations/meta/0008_snapshot.json
+++ b/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1419 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "be51ddb5-15fe-4102-ba79-3c54b0f116e9",
+  "prevId": "fe3cdff8-34d4-41b3-aea6-24dbdd3d6abf",
+  "tables": {
+    "ai_conversations": {
+      "name": "ai_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_conversations_provider_id_model_providers_id_fk": {
+          "name": "ai_conversations_provider_id_model_providers_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_messages": {
+      "name": "ai_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_messages_conversation_id_ai_conversations_id_fk": {
+          "name": "ai_messages_conversation_id_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "checklist_runs": {
+      "name": "checklist_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_type": {
+          "name": "checklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "final_judgment": {
+          "name": "final_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_runs_company_id_companies_id_fk": {
+          "name": "checklist_runs_company_id_companies_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "checklist_runs_principle_id_investment_principles_id_fk": {
+          "name": "checklist_runs_principle_id_investment_principles_id_fk",
+          "tableFrom": "checklist_runs",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_code": {
+          "name": "stock_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_name": {
+          "name": "stock_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "watch_status": {
+          "name": "watch_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'watching'"
+        },
+        "valuation_status": {
+          "name": "valuation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "in_circle": {
+          "name": "in_circle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "thesis": {
+          "name": "thesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "key_risks": {
+          "name": "key_risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_checklist_templates": {
+      "name": "custom_checklist_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_type": {
+          "name": "checklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decisions": {
+      "name": "decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checklist_run_id": {
+          "name": "checklist_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principle_id": {
+          "name": "principle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_type": {
+          "name": "decision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "final_user_judgment": {
+          "name": "final_user_judgment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_assumptions": {
+          "name": "key_assumptions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risks": {
+          "name": "risks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "opponent_summary": {
+          "name": "opponent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "decision_date": {
+          "name": "decision_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "decisions_company_id_companies_id_fk": {
+          "name": "decisions_company_id_companies_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_checklist_run_id_checklist_runs_id_fk": {
+          "name": "decisions_checklist_run_id_checklist_runs_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "checklist_runs",
+          "columnsFrom": [
+            "checklist_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "decisions_principle_id_investment_principles_id_fk": {
+          "name": "decisions_principle_id_investment_principles_id_fk",
+          "tableFrom": "decisions",
+          "tableTo": "investment_principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "investment_principles": {
+      "name": "investment_principles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'我的 A 股价值投资原则'"
+        },
+        "circle_of_competence": {
+          "name": "circle_of_competence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "excluded_industries": {
+          "name": "excluded_industries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_financial_quality": {
+          "name": "minimum_financial_quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "minimum_margin_of_safety": {
+          "name": "minimum_margin_of_safety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_rules": {
+          "name": "position_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "buy_rules": {
+          "name": "buy_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sell_rules": {
+          "name": "sell_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_nothing_rules": {
+          "name": "do_nothing_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "risk_rules": {
+          "name": "risk_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_nodes": {
+      "name": "knowledge_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "learning_progress": {
+      "name": "learning_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "mastery_score": {
+          "name": "mastery_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_configs_provider_id_model_providers_id_fk": {
+          "name": "model_configs_provider_id_model_providers_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_providers": {
+      "name": "model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_openai_compatible": {
+          "name": "is_openai_compatible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_insecure_tls": {
+          "name": "allow_insecure_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_name": {
+          "name": "default_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_temperature": {
+          "name": "default_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        },
+        "max_context_tokens": {
+          "name": "max_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8000
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "last_test_status": {
+          "name": "last_test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_tested'"
+        },
+        "last_test_message": {
+          "name": "last_test_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_type": {
+          "name": "review_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'post_decision'"
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "what_happened": {
+          "name": "what_happened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assumptions_validated": {
+          "name": "assumptions_validated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assumptions_failed": {
+          "name": "assumptions_failed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lessons": {
+          "name": "lessons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "principle_changes_needed": {
+          "name": "principle_changes_needed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_decision_id_decisions_id_fk": {
+          "name": "reviews_decision_id_decisions_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_company_id_companies_id_fk": {
+          "name": "reviews_company_id_companies_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "training_results": {
+      "name": "training_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_set_json": {
+          "name": "question_set_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "answers_json": {
+          "name": "answers_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "weak_topics_json": {
+          "name": "weak_topics_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "answered_count": {
+          "name": "answered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "review_advice": {
+          "name": "review_advice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "examiner_prompt": {
+          "name": "examiner_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "valuations": {
+      "name": "valuations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_type": {
+          "name": "template_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "valuation_date": {
+          "name": "valuation_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shares_outstanding": {
+          "name": "shares_outstanding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CNY'"
+        },
+        "scenario_bear_json": {
+          "name": "scenario_bear_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_base_json": {
+          "name": "scenario_base_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "scenario_bull_json": {
+          "name": "scenario_bull_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "valuations_company_id_companies_id_fk": {
+          "name": "valuations_company_id_companies_id_fk",
+          "tableFrom": "valuations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777727487060,
       "tag": "0007_naive_warbound",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1777772958137,
+      "tag": "0008_flashy_giant_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -66,6 +66,30 @@ export const knowledgeNodes = sqliteTable("knowledge_nodes", {
   updatedAt: text("updated_at").notNull()
 });
 
+export const learningProgress = sqliteTable("learning_progress", {
+  id: text("id").primaryKey(),
+  nodeId: text("node_id").notNull(),
+  status: text("status").notNull().default("not_started"),
+  masteryScore: integer("mastery_score").notNull().default(0),
+  notes: text("notes").notNull().default(""),
+  completedAt: text("completed_at"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const trainingResults = sqliteTable("training_results", {
+  id: text("id").primaryKey(),
+  questionSetJson: text("question_set_json").notNull().default("[]"),
+  answersJson: text("answers_json").notNull().default("{}"),
+  weakTopicsJson: text("weak_topics_json").notNull().default("[]"),
+  answeredCount: integer("answered_count").notNull().default(0),
+  correctCount: integer("correct_count").notNull().default(0),
+  score: integer("score").notNull().default(0),
+  reviewAdvice: text("review_advice").notNull().default(""),
+  examinerPrompt: text("examiner_prompt").notNull().default(""),
+  createdAt: text("created_at").notNull()
+});
+
 export const companies = sqliteTable("companies", {
   id: text("id").primaryKey(),
   stockCode: text("stock_code").notNull(),

--- a/src/lib/learning/progress.ts
+++ b/src/lib/learning/progress.ts
@@ -1,0 +1,33 @@
+import { desc } from "drizzle-orm";
+import { db } from "@/db/client";
+import { learningProgress, trainingResults } from "@/db/schema";
+import type { LearningStatus } from "@/lib/learning/status";
+
+export type LearningProgressRow = typeof learningProgress.$inferSelect;
+export type TrainingResultRow = typeof trainingResults.$inferSelect;
+
+export async function getLearningProgressRows() {
+  return db.select().from(learningProgress);
+}
+
+export async function getLearningProgressByNodeId() {
+  const rows = await getLearningProgressRows();
+  return Object.fromEntries(rows.map((row) => [row.nodeId, row]));
+}
+
+export async function getRecentTrainingResults(limit = 5) {
+  return db
+    .select()
+    .from(trainingResults)
+    .orderBy(desc(trainingResults.createdAt))
+    .limit(limit);
+}
+
+export function parseWeakTopics(value: string) {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/learning/status.ts
+++ b/src/lib/learning/status.ts
@@ -1,0 +1,7 @@
+export type LearningStatus = "not_started" | "in_progress" | "completed";
+
+export const learningStatusLabels: Record<LearningStatus, string> = {
+  not_started: "未开始",
+  in_progress: "学习中",
+  completed: "已学完"
+};


### PR DESCRIPTION
## 关联 Issue

Closes #37

## 改动摘要

- 新增学习进度表，支持知识节点标记为未开始、学习中、已学完。
- 新增训练结果表，保存训练题集、答案、得分、薄弱主题和复习建议。
- 学习地图展示已学数量、学习中数量和节点状态。
- 知识节点详情页增加学习状态操作区。
- 训练场提交后保存训练结果，并展示最近训练记录。
- 导入导出备份同步覆盖学习进度和训练结果。
- 学习页、节点详情页、训练页改为动态渲染，避免本地数据库状态被静态缓存。

## 主要文件

- app/learn/page.tsx
- app/learn/[nodeId]/page.tsx
- app/learn/actions.ts
- app/training/page.tsx
- app/training/actions.ts
- src/components/learning/learning-map.tsx
- src/components/training/training-arena.tsx
- src/db/schema.ts
- src/db/migrations/0008_flashy_giant_girl.sql

## 验证

- [x] npm run db:generate
- [x] npm run db:migrate
- [x] npm run typecheck
- [x] npm run build
- [x] 手动验证学习节点状态保存和学习地图计数
- [x] 验证 /learn、/training 页面可渲染
- [x] 验证 dev CSS 资源 200

## 截图 / 说明

本地页面新增学习状态卡片、学习地图状态徽标、训练场最近训练面板。

## 数据库迁移

新增两张表：

- learning_progress：保存知识节点学习状态、掌握度、完成时间。
- training_results：保存训练提交、得分、薄弱主题和复习建议。

只新增表，不修改已有表字段。

## 风险

涉及数据库迁移和 Server Action。已将读取本地数据库的学习/训练页面设为动态渲染，降低缓存导致状态不更新的风险。

## 回退方案

如需回退，直接 revert 本 PR；新增表不影响已有业务表。