### PR TITLE
新增决策详情页与待复盘提醒

### DIFF
--- a/app/reviews/decisions/[decisionId]/page.tsx
+++ b/app/reviews/decisions/[decisionId]/page.tsx
@@ -1,0 +1,392 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  ArrowLeft,
+  Bot,
+  Calculator,
+  ClipboardCheck,
+  FileText,
+  RotateCcw,
+  ShieldAlert
+} from "lucide-react";
+import { SectionHeader } from "@/components/ui/section-header";
+import type { checklistRuns, investmentPrinciples, reviews, valuations } from "@/db/schema";
+import {
+  checklistStatuses,
+  checklistTypes,
+  labelFor as checklistLabelFor
+} from "@/lib/investment-system/constants";
+import { getDecisionDetailData } from "@/lib/reviews/queries";
+import { labelFor as reviewLabelFor, reviewTypes } from "@/lib/reviews/constants";
+import { getTemplate } from "@/lib/valuations/constants";
+import type { ValuationResult } from "@/lib/valuations/calculations";
+
+type DecisionDetailPageProps = {
+  params: Promise<{
+    decisionId: string;
+  }>;
+};
+
+type ChecklistRun = typeof checklistRuns.$inferSelect;
+type Principle = typeof investmentPrinciples.$inferSelect;
+type Review = typeof reviews.$inferSelect;
+type Valuation = typeof valuations.$inferSelect;
+
+type ChecklistRunItem = {
+  id: string;
+  text: string;
+  category: string;
+  required: boolean;
+  status: string;
+  note: string;
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function DecisionDetailPage({ params }: DecisionDetailPageProps) {
+  const { decisionId } = await params;
+  const data = await getDecisionDetailData(decisionId);
+
+  if (!data) {
+    notFound();
+  }
+
+  const { decision, company, checklistRun, principle, reviews, valuations } = data;
+  const companyName = company ? `${company.stockName}（${company.stockCode}）` : "未关联公司";
+  const mentorDraft = `请作为耐心的价值投资导师，帮我复盘这条 A 股投资决策记录。不要给买入、卖出或持有建议，只帮助我检查假设、证据、风险和后续学习方向。公司=${companyName}；用户最终判断=${decision.finalUserJudgment}；关键假设=${decision.keyAssumptions || "未填写"}；主要风险=${decision.risks || "未填写"}；已有复盘=${reviews.map((review) => `${review.reviewDate}：${review.lessons}`).join("；") || "暂无"}。`;
+  const opponentDraft = `请作为投资委员会反方委员，质疑这条 A 股投资决策记录。不要给买入、卖出或持有建议，只指出反方问题、遗漏证据、原则冲突和可能的归因错误。公司=${companyName}；用户最终判断=${decision.finalUserJudgment}；关键假设=${decision.keyAssumptions || "未填写"}；主要风险=${decision.risks || "未填写"}；检查摘要=${checklistRun?.summary || "未关联检查清单"}。`;
+
+  return (
+    <main className="space-y-8">
+      <Link
+        href="/reviews"
+        className="inline-flex items-center gap-2 text-sm font-semibold text-muted-foreground transition hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        返回复盘
+      </Link>
+
+      <section className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <SectionHeader
+            title="决策详情"
+            description="回看这次判断的证据链：公司、检查清单、关键假设、主要风险、关联原则、估值记录和后续复盘。"
+          />
+          <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
+            <Metric label="日期" value={decision.decisionDate} />
+            <Metric label="类型" value={checklistLabelFor(checklistTypes, decision.decisionType)} />
+            <Metric label="复盘" value={`${reviews.length} 条`} />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <div className="space-y-6">
+          <DecisionSnapshot
+            companyName={companyName}
+            decisionType={decision.decisionType}
+            decisionDate={decision.decisionDate}
+            finalUserJudgment={decision.finalUserJudgment}
+            keyAssumptions={decision.keyAssumptions}
+            risks={decision.risks}
+          />
+          <ChecklistEvidence checklistRun={checklistRun} />
+          <ReviewHistory reviews={reviews} />
+        </div>
+
+        <div className="space-y-6">
+          <ActionPanel decisionId={decision.id} mentorDraft={mentorDraft} opponentDraft={opponentDraft} />
+          <PrincipleSnapshot principle={principle} />
+          <RelatedValuations valuations={valuations} />
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function DecisionSnapshot({
+  companyName,
+  decisionType,
+  decisionDate,
+  finalUserJudgment,
+  keyAssumptions,
+  risks
+}: {
+  companyName: string;
+  decisionType: string;
+  decisionDate: string;
+  finalUserJudgment: string;
+  keyAssumptions: string;
+  risks: string;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <FileText className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">用户决策记录</h2>
+      </div>
+      <div className="mt-5 grid gap-3 md:grid-cols-3">
+        <InfoBlock title="公司" value={companyName} />
+        <InfoBlock title="决策类型" value={checklistLabelFor(checklistTypes, decisionType)} />
+        <InfoBlock title="决策日期" value={decisionDate} />
+      </div>
+      <div className="mt-4 rounded-md border border-border bg-background p-4">
+        <div className="text-xs font-semibold text-primary">最终判断</div>
+        <p className="mt-2 text-sm leading-6">{finalUserJudgment}</p>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <InfoBlock title="关键假设" value={keyAssumptions || "未填写"} />
+        <InfoBlock title="主要风险" value={risks || "未填写"} />
+      </div>
+    </section>
+  );
+}
+
+function ChecklistEvidence({ checklistRun }: { checklistRun: ChecklistRun | null }) {
+  const items = checklistRun ? parseChecklistItems(checklistRun.itemsJson) : [];
+  const issueCount = items.filter((item) => item.required && (item.status === "fail" || item.status === "unknown")).length;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-center gap-2">
+          <ClipboardCheck className="h-5 w-5 text-primary" aria-hidden />
+          <h2 className="text-xl font-semibold">检查清单证据</h2>
+        </div>
+        {checklistRun ? (
+          <span className="rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-muted-foreground">
+            关键未确认/失败 {issueCount} 项
+          </span>
+        ) : null}
+      </div>
+
+      {!checklistRun ? (
+        <EmptyState text="这条决策没有关联检查清单。后续建议从投资系统页面通过检查清单生成决策。" />
+      ) : (
+        <div className="mt-5 space-y-3">
+          <InfoBlock title="检查摘要" value={checklistRun.summary || "未填写"} />
+          {items.map((item) => (
+            <article key={item.id} className="rounded-md border border-border bg-background p-4">
+              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-primary">
+                    <span>{item.category}</span>
+                    {item.required ? <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">关键项</span> : null}
+                  </div>
+                  <p className="mt-2 text-sm leading-6">{item.text}</p>
+                </div>
+                <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+                  {checklistLabelFor(checklistStatuses, item.status)}
+                </span>
+              </div>
+              {item.note ? <p className="mt-3 text-sm leading-6 text-muted-foreground">备注：{item.note}</p> : null}
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ActionPanel({
+  decisionId,
+  mentorDraft,
+  opponentDraft
+}: {
+  decisionId: string;
+  mentorDraft: string;
+  opponentDraft: string;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <h2 className="text-xl font-semibold">下一步动作</h2>
+      <div className="mt-5 grid gap-3">
+        <Link
+          href={`/reviews?decisionId=${decisionId}#review-form`}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
+        >
+          <RotateCcw className="h-4 w-4" aria-hidden />
+          创建这条决策的复盘
+        </Link>
+        <Link
+          href={`/mentor?role=mentor&draft=${encodeURIComponent(mentorDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <Bot className="h-4 w-4" aria-hidden />
+          让导师总结
+        </Link>
+        <Link
+          href={`/mentor?role=opponent&draft=${encodeURIComponent(opponentDraft)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-semibold transition hover:bg-muted"
+        >
+          <ShieldAlert className="h-4 w-4" aria-hidden />
+          让反方委员追问
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function PrincipleSnapshot({ principle }: { principle: Principle | null }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <h2 className="text-xl font-semibold">关联原则</h2>
+      {!principle ? (
+        <EmptyState text="这条决策没有关联投资原则。建议先在投资系统页面保存一套原则。" />
+      ) : (
+        <div className="mt-5 space-y-3">
+          <InfoBlock title="原则名称" value={`${principle.title} / v${principle.version}`} />
+          <InfoBlock title="能力圈" value={principle.circleOfCompetence || "未填写"} />
+          <InfoBlock title="安全边际要求" value={principle.minimumMarginOfSafety || "未填写"} />
+          <InfoBlock title="风险规则" value={principle.riskRules || "未填写"} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RelatedValuations({ valuations }: { valuations: Valuation[] }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <Calculator className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">相关估值</h2>
+      </div>
+      <div className="mt-5 space-y-3">
+        {valuations.length === 0 ? (
+          <EmptyState text="这家公司还没有估值记录。可以先补一条三情景估值，再回到决策详情对照假设。" />
+        ) : (
+          valuations.map((valuation) => {
+            const template = getTemplate(valuation.templateType);
+            const result = parseValuationResult(valuation.resultJson);
+
+            return (
+              <article key={valuation.id} className="rounded-md border border-border bg-background p-4">
+                <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <div className="text-sm font-semibold">{valuation.title}</div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {template.label} / {valuation.valuationDate}
+                    </p>
+                  </div>
+                  <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+                    中性 {formatPrice(result?.baseValuePerShare)}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  区间：{formatPrice(result?.lowValuePerShare)} - {formatPrice(result?.highValuePerShare)}；中性安全边际：
+                  {formatPercent(result?.baseMarginOfSafety)}
+                </p>
+              </article>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ReviewHistory({ reviews }: { reviews: Review[] }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2">
+        <RotateCcw className="h-5 w-5 text-primary" aria-hidden />
+        <h2 className="text-xl font-semibold">已关联复盘</h2>
+      </div>
+      <div className="mt-5 space-y-3">
+        {reviews.length === 0 ? (
+          <EmptyState text="还没有复盘。建议在事实变化、财报更新或情绪波动后，回到这里写一次复盘。" />
+        ) : (
+          reviews.map((review) => (
+            <article key={review.id} className="rounded-md border border-border bg-background p-4">
+              <div className="text-sm font-semibold">
+                {reviewLabelFor(reviewTypes, review.reviewType)} / {review.reviewDate}
+              </div>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <InfoBlock title="实际发生" value={review.whatHappened || "未填写"} />
+                <InfoBlock title="经验教训" value={review.lessons || "未填写"} />
+                <InfoBlock title="成立假设" value={review.assumptionsValidated || "未填写"} />
+                <InfoBlock title="失败假设" value={review.assumptionsFailed || "未填写"} />
+              </div>
+              {review.principleChangesNeeded ? (
+                <div className="mt-3 rounded-md border border-border bg-card p-3">
+                  <div className="text-xs font-semibold text-primary">原则修订建议</div>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">{review.principleChangesNeeded}</p>
+                </div>
+              ) : null}
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function InfoBlock({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-background p-3">
+      <div className="text-xs font-semibold text-primary">{title}</div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{value}</p>
+    </div>
+  );
+}
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="mt-5 rounded-lg border border-dashed border-border bg-background p-5 text-sm leading-6 text-muted-foreground">
+      {text}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-20 rounded-md bg-card px-4 py-3">
+      <div className="text-sm font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+function parseChecklistItems(value: string): ChecklistRunItem[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((item): ChecklistRunItem => {
+        const row = item as Partial<ChecklistRunItem>;
+
+        return {
+          id: typeof row.id === "string" ? row.id : crypto.randomUUID(),
+          text: typeof row.text === "string" ? row.text : "",
+          category: typeof row.category === "string" ? row.category : "通用",
+          required: Boolean(row.required),
+          status: typeof row.status === "string" ? row.status : "unknown",
+          note: typeof row.note === "string" ? row.note : ""
+        };
+      })
+      .filter((item) => item.text);
+  } catch {
+    return [];
+  }
+}
+
+function parseValuationResult(value: string): ValuationResult | null {
+  try {
+    return JSON.parse(value) as ValuationResult;
+  } catch {
+    return null;
+  }
+}
+
+function formatPrice(value?: number) {
+  return typeof value === "number" && Number.isFinite(value) ? `${value.toFixed(2)} 元` : "未计算";
+}
+
+function formatPercent(value?: number) {
+  return typeof value === "number" && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : "未计算";
+}

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -1,14 +1,25 @@
 import Link from "next/link";
-import { AlertCircle, Bot, CheckCircle2, History, RotateCcw, ShieldAlert } from "lucide-react";
+import {
+  AlertCircle,
+  Bot,
+  CalendarClock,
+  CheckCircle2,
+  FileText,
+  History,
+  RotateCcw,
+  ShieldAlert
+} from "lucide-react";
 import { PendingButton } from "@/components/ui/pending-button";
 import { SectionHeader } from "@/components/ui/section-header";
 import type { companies, decisions, reviews } from "@/db/schema";
+import { checklistTypes, labelFor as checklistLabelFor } from "@/lib/investment-system/constants";
 import { labelFor, reviewTypes } from "@/lib/reviews/constants";
 import { getReviewsPageData } from "@/lib/reviews/queries";
 import { saveReview } from "./actions";
 
 type ReviewsPageProps = {
   searchParams?: Promise<{
+    decisionId?: string;
     status?: string;
     message?: string;
   }>;
@@ -18,8 +29,11 @@ type Company = typeof companies.$inferSelect;
 type Decision = typeof decisions.$inferSelect;
 type Review = typeof reviews.$inferSelect;
 
+export const dynamic = "force-dynamic";
+
 export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
-  const paramsPromise: Promise<{ status?: string; message?: string }> = searchParams ?? Promise.resolve({});
+  const paramsPromise: Promise<{ decisionId?: string; status?: string; message?: string }> =
+    searchParams ?? Promise.resolve({});
   const [params, data] = await Promise.all([paramsPromise, getReviewsPageData()]);
 
   return (
@@ -33,7 +47,7 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
           <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
             <Metric label="决策" value={data.decisions.length} />
             <Metric label="复盘" value={data.reviews.length} />
-            <Metric label="类型" value={reviewTypes.length} />
+            <Metric label="待复盘" value={data.pendingDecisions.length} />
           </div>
         </div>
       </section>
@@ -42,21 +56,88 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
         <StatusBanner status={params.status === "success" ? "success" : "error"} message={params.message} />
       ) : null}
 
+      <PendingReviewDecisions decisions={data.pendingDecisions} />
+
       <section className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
-        <ReviewForm decisions={data.decisions} />
+        <ReviewForm decisions={data.decisions} selectedDecisionId={params.decisionId} />
         <RecentReviews reviews={data.reviews} />
       </section>
     </main>
   );
 }
 
-function ReviewForm({
+function PendingReviewDecisions({
   decisions
 }: {
   decisions: Array<{ decision: Decision; company: Company | null }>;
 }) {
   return (
     <section className="rounded-lg border border-border bg-card p-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-5 w-5 text-primary" aria-hidden />
+          <h2 className="text-xl font-semibold">待复盘决策</h2>
+        </div>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          这些决策还没有关联复盘。优先回看关键假设、风险和当时检查项，再记录事实验证结果。
+        </p>
+      </div>
+
+      <div className="mt-5 grid gap-3 lg:grid-cols-2">
+        {decisions.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-background p-5 text-sm leading-6 text-muted-foreground lg:col-span-2">
+            暂无待复盘决策。新的检查清单生成决策后，会出现在这里。
+          </div>
+        ) : (
+          decisions.map(({ decision, company }) => (
+            <article key={decision.id} className="rounded-lg border border-border bg-background p-4">
+              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div className="text-sm font-semibold">
+                    {company ? `${company.stockName}（${company.stockCode}）` : "未关联公司"}
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {decision.decisionDate} / {checklistLabelFor(checklistTypes, decision.decisionType)}
+                  </p>
+                </div>
+                <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+                  未复盘
+                </span>
+              </div>
+              <p className="mt-3 line-clamp-2 text-sm leading-6">{decision.finalUserJudgment}</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Link
+                  href={`/reviews/decisions/${decision.id}`}
+                  className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+                >
+                  <FileText className="h-4 w-4" aria-hidden />
+                  查看决策详情
+                </Link>
+                <Link
+                  href={`/reviews?decisionId=${decision.id}#review-form`}
+                  className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
+                >
+                  <RotateCcw className="h-4 w-4" aria-hidden />
+                  创建复盘
+                </Link>
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ReviewForm({
+  decisions,
+  selectedDecisionId
+}: {
+  decisions: Array<{ decision: Decision; company: Company | null }>;
+  selectedDecisionId?: string;
+}) {
+  return (
+    <section id="review-form" className="rounded-lg border border-border bg-card p-6">
       <div className="flex items-center gap-2">
         <RotateCcw className="h-5 w-5 text-primary" aria-hidden />
         <h2 className="text-xl font-semibold">创建复盘</h2>
@@ -71,6 +152,7 @@ function ReviewForm({
             <span className="text-sm font-semibold">关联决策</span>
             <select
               name="decisionId"
+              defaultValue={selectedDecisionId ?? ""}
               className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none transition focus:border-primary"
             >
               <option value="">不关联决策</option>
@@ -183,6 +265,15 @@ function ReviewCard({
       ) : null}
 
       <div className="mt-4 flex flex-wrap gap-2">
+        {decision ? (
+          <Link
+            href={`/reviews/decisions/${decision.id}`}
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+          >
+            <FileText className="h-4 w-4" aria-hidden />
+            查看决策详情
+          </Link>
+        ) : null}
         <Link
           href={`/mentor?role=mentor&draft=${encodeURIComponent(mentorDraft)}`}
           className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   CheckCircle2,
   ClipboardCheck,
+  FileText,
   FilePenLine,
   History,
   ShieldAlert
@@ -356,6 +357,13 @@ function DecisionLog({ decisions }: { decisions: Array<{ decision: Decision; com
                   <InfoBlock title="主要风险" value={decision.risks || "未填写"} />
                 </div>
               ) : null}
+              <Link
+                href={`/reviews/decisions/${decision.id}`}
+                className="mt-4 inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold transition hover:bg-muted"
+              >
+                <FileText className="h-4 w-4" aria-hidden />
+                查看决策详情
+              </Link>
             </article>
           ))
         )}

--- a/src/lib/reviews/queries.ts
+++ b/src/lib/reviews/queries.ts
@@ -1,9 +1,16 @@
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, isNull } from "drizzle-orm";
 import { db } from "@/db/client";
-import { companies, decisions, reviews } from "@/db/schema";
+import {
+  checklistRuns,
+  companies,
+  decisions,
+  investmentPrinciples,
+  reviews,
+  valuations
+} from "@/db/schema";
 
 export async function getReviewsPageData() {
-  const [decisionRows, reviewRows] = await Promise.all([
+  const [decisionRows, pendingDecisionRows, reviewRows] = await Promise.all([
     db
       .select({
         decision: decisions,
@@ -13,6 +20,17 @@ export async function getReviewsPageData() {
       .leftJoin(companies, eq(decisions.companyId, companies.id))
       .orderBy(desc(decisions.createdAt))
       .limit(20),
+    db
+      .select({
+        decision: decisions,
+        company: companies
+      })
+      .from(decisions)
+      .leftJoin(companies, eq(decisions.companyId, companies.id))
+      .leftJoin(reviews, eq(reviews.decisionId, decisions.id))
+      .where(isNull(reviews.id))
+      .orderBy(desc(decisions.createdAt))
+      .limit(8),
     db
       .select({
         review: reviews,
@@ -28,6 +46,53 @@ export async function getReviewsPageData() {
 
   return {
     decisions: decisionRows,
+    pendingDecisions: pendingDecisionRows,
     reviews: reviewRows
+  };
+}
+
+export async function getDecisionDetailData(decisionId: string) {
+  const [decisionRow] = await db
+    .select({
+      decision: decisions,
+      company: companies,
+      checklistRun: checklistRuns,
+      principle: investmentPrinciples
+    })
+    .from(decisions)
+    .leftJoin(companies, eq(decisions.companyId, companies.id))
+    .leftJoin(checklistRuns, eq(decisions.checklistRunId, checklistRuns.id))
+    .leftJoin(investmentPrinciples, eq(decisions.principleId, investmentPrinciples.id))
+    .where(eq(decisions.id, decisionId))
+    .limit(1);
+
+  if (!decisionRow) {
+    return null;
+  }
+
+  const [reviewRows, valuationRows] = await Promise.all([
+    db
+      .select({
+        review: reviews
+      })
+      .from(reviews)
+      .where(eq(reviews.decisionId, decisionId))
+      .orderBy(desc(reviews.reviewDate), desc(reviews.createdAt)),
+    decisionRow.decision.companyId
+      ? db
+          .select({
+            valuation: valuations
+          })
+          .from(valuations)
+          .where(eq(valuations.companyId, decisionRow.decision.companyId))
+          .orderBy(desc(valuations.valuationDate), desc(valuations.createdAt))
+          .limit(5)
+      : Promise.resolve([])
+  ]);
+
+  return {
+    ...decisionRow,
+    reviews: reviewRows.map((row) => row.review),
+    valuations: valuationRows.map((row) => row.valuation)
   };
 }


### PR DESCRIPTION
## 关联 Issue

Closes #41

## 改动摘要

- 复盘页新增待复盘决策提醒，展示尚未关联复盘的决策。
- 复盘页支持通过 decisionId 参数预选关联决策，方便从待复盘卡片直接创建复盘。
- 新增决策详情页 /reviews/decisions/decisionId。
- 决策详情页聚合用户最终判断、关键假设、主要风险、检查清单、关联原则、相关估值和已有复盘。
- 决策详情页增加创建复盘、导师总结、反方追问入口。
- 投资系统的决策日志增加“查看决策详情”入口。
- 复盘页与决策详情页设为动态渲染，避免本地数据库页面缓存。

## 主要文件

- app/reviews/page.tsx
- app/reviews/decisions/[decisionId]/page.tsx
- app/system/page.tsx
- src/lib/reviews/queries.ts

## 验证

- [x] npm run typecheck
- [x] npm run build
- [x] 验证 /reviews 返回 200
- [x] 验证 /reviews/decisions/faedc94a-59f4-42eb-9d09-fb03f736db49 返回 200
- [x] 验证 CSS 资源返回 200

## 产品边界

页面只展示用户记录、证据链和 AI 追问入口，不输出买入、卖出、持有建议，也不生成任何自动交易信号。

## 风险

本次不新增数据库迁移，主要风险是页面信息聚合字段为空时的展示。已为未关联公司、未关联原则、无估值、无复盘场景增加空状态。

## 回退方案

如需回退，直接 revert 本 PR；不影响已有决策、复盘、观察池和估值数据。