### PR TITLE
新增投资原则版本历史与对比

### DIFF
--- a/app/system/actions.ts
+++ b/app/system/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { checklistRuns, customChecklistTemplates, decisions, investmentPrinciples } from "@/db/schema";
@@ -57,6 +57,24 @@ function statusRedirect(status: string, message: string): never {
   redirect(`/system?status=${encodeURIComponent(status)}&message=${encodeURIComponent(message)}`);
 }
 
+function principleValuesChanged(
+  current: typeof investmentPrinciples.$inferSelect,
+  next: Omit<z.infer<typeof principleSchema>, "principleId">
+) {
+  return (
+    current.title !== next.title ||
+    current.circleOfCompetence !== next.circleOfCompetence ||
+    current.excludedIndustries !== next.excludedIndustries ||
+    current.minimumFinancialQuality !== next.minimumFinancialQuality ||
+    current.minimumMarginOfSafety !== next.minimumMarginOfSafety ||
+    current.positionRules !== next.positionRules ||
+    current.buyRules !== next.buyRules ||
+    current.sellRules !== next.sellRules ||
+    current.doNothingRules !== next.doNothingRules ||
+    current.riskRules !== next.riskRules
+  );
+}
+
 export async function saveInvestmentPrinciple(formData: FormData) {
   const parsed = principleSchema.safeParse({
     principleId: String(formData.get("principleId") ?? "").trim() || undefined,
@@ -80,16 +98,58 @@ export async function saveInvestmentPrinciple(formData: FormData) {
 
   if (parsed.data.principleId) {
     const { principleId, ...values } = parsed.data;
+    const [currentPrinciple] = await db
+      .select()
+      .from(investmentPrinciples)
+      .where(eq(investmentPrinciples.id, principleId))
+      .limit(1);
+
+    if (!currentPrinciple) {
+      statusRedirect("error", "未找到要更新的投资原则。");
+    }
+
+    if (!principleValuesChanged(currentPrinciple, values)) {
+      statusRedirect("success", `投资原则未变化，仍为 v${currentPrinciple.version}。`);
+    }
+
     await db
       .update(investmentPrinciples)
       .set({
-        ...values,
-        version: 1,
-        active: true,
-        updatedAt
+        active: false
       })
-      .where(eq(investmentPrinciples.id, principleId));
+      .where(eq(investmentPrinciples.active, true));
+
+    await db.insert(investmentPrinciples).values({
+      id: crypto.randomUUID(),
+      title: values.title,
+      circleOfCompetence: values.circleOfCompetence,
+      excludedIndustries: values.excludedIndustries,
+      minimumFinancialQuality: values.minimumFinancialQuality,
+      minimumMarginOfSafety: values.minimumMarginOfSafety,
+      positionRules: values.positionRules,
+      buyRules: values.buyRules,
+      sellRules: values.sellRules,
+      doNothingRules: values.doNothingRules,
+      riskRules: values.riskRules,
+      version: currentPrinciple.version + 1,
+      active: true,
+      createdAt: updatedAt,
+      updatedAt
+    });
   } else {
+    const [latestPrinciple] = await db
+      .select()
+      .from(investmentPrinciples)
+      .orderBy(desc(investmentPrinciples.version), desc(investmentPrinciples.createdAt))
+      .limit(1);
+
+    await db
+      .update(investmentPrinciples)
+      .set({
+        active: false
+      })
+      .where(eq(investmentPrinciples.active, true));
+
     await db.insert(investmentPrinciples).values({
       id: crypto.randomUUID(),
       title: parsed.data.title,
@@ -102,7 +162,7 @@ export async function saveInvestmentPrinciple(formData: FormData) {
       sellRules: parsed.data.sellRules,
       doNothingRules: parsed.data.doNothingRules,
       riskRules: parsed.data.riskRules,
-      version: 1,
+      version: latestPrinciple ? latestPrinciple.version + 1 : 1,
       active: true,
       createdAt: updatedAt,
       updatedAt
@@ -110,7 +170,7 @@ export async function saveInvestmentPrinciple(formData: FormData) {
   }
 
   revalidatePath("/system");
-  statusRedirect("success", "投资原则已保存。");
+  statusRedirect("success", "投资原则已保存为新版本。");
 }
 
 export async function saveChecklistRun(formData: FormData) {

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -55,8 +55,8 @@ export default async function SystemPage({ searchParams }: SystemPageProps) {
           />
           <div className="grid grid-cols-3 gap-2 rounded-lg border border-border bg-background p-3 text-center">
             <Metric label="原则" value={data.principle ? 1 : 0} />
+            <Metric label="版本" value={data.principleHistory.length} />
             <Metric label="检查" value={data.recentRuns.length} />
-            <Metric label="决策" value={data.recentDecisions.length} />
           </div>
         </div>
       </section>
@@ -74,6 +74,8 @@ export default async function SystemPage({ searchParams }: SystemPageProps) {
         />
       </section>
 
+      <PrincipleVersionPanel versions={data.principleHistory} />
+
       <ChecklistTemplateEditor templates={data.checklistTemplates} saveAction={saveChecklistTemplate} />
 
       <section className="grid gap-6 xl:grid-cols-2">
@@ -83,6 +85,19 @@ export default async function SystemPage({ searchParams }: SystemPageProps) {
     </main>
   );
 }
+
+const principleDiffFields: Array<{ key: keyof Principle; label: string }> = [
+  { key: "title", label: "原则名称" },
+  { key: "circleOfCompetence", label: "能力圈" },
+  { key: "excludedIndustries", label: "不碰行业 / 情形" },
+  { key: "minimumFinancialQuality", label: "财务质量底线" },
+  { key: "minimumMarginOfSafety", label: "安全边际要求" },
+  { key: "positionRules", label: "仓位规则" },
+  { key: "buyRules", label: "买入规则" },
+  { key: "sellRules", label: "卖出规则" },
+  { key: "doNothingRules", label: "不操作规则" },
+  { key: "riskRules", label: "风险规则" }
+];
 
 function PrinciplePanel({ principle }: { principle?: Principle }) {
   const auditDraft = `请作为投资委员会反方委员，检查我的 A 股价值投资原则是否足够清晰、可执行、可反证。不要替我制定最终原则，也不要给买卖建议。我的原则如下：能力圈=${principle?.circleOfCompetence || "未填写"}；不碰行业=${principle?.excludedIndustries || "未填写"}；财务质量=${principle?.minimumFinancialQuality || "未填写"}；安全边际=${principle?.minimumMarginOfSafety || "未填写"}；买入规则=${principle?.buyRules || "未填写"}；卖出规则=${principle?.sellRules || "未填写"}；不操作规则=${principle?.doNothingRules || "未填写"}。`;
@@ -126,6 +141,82 @@ function PrinciplePanel({ principle }: { principle?: Principle }) {
           保存投资原则
         </PendingButton>
       </form>
+    </section>
+  );
+}
+
+function PrincipleVersionPanel({ versions }: { versions: Principle[] }) {
+  const current = versions.find((version) => version.active) ?? versions[0];
+  const previous = versions.find((version) => current && version.id !== current.id);
+  const changes =
+    current && previous
+      ? principleDiffFields.filter(({ key }) => String(current[key] ?? "") !== String(previous[key] ?? ""))
+      : [];
+
+  return (
+    <section className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="flex items-center gap-2">
+          <History className="h-5 w-5 text-primary" aria-hidden />
+          <h2 className="text-xl font-semibold">原则版本历史</h2>
+        </div>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          每次修改投资原则都会生成新版本，旧版本保留用于复盘和追溯。
+        </p>
+
+        <div className="mt-5 space-y-3">
+          {versions.length === 0 ? (
+            <EmptyState text="还没有保存过投资原则。先保存一版原则，后续修改会自动形成历史版本。" />
+          ) : (
+            versions.map((version) => (
+              <article key={version.id} className="rounded-lg border border-border bg-background p-4">
+                <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <div className="text-sm font-semibold">
+                      v{version.version} / {version.title}
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      创建 {version.createdAt.slice(0, 10)} / 更新 {version.updatedAt.slice(0, 10)}
+                    </p>
+                  </div>
+                  <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+                    {version.active ? "当前版本" : "历史版本"}
+                  </span>
+                </div>
+                <p className="mt-3 line-clamp-2 text-sm leading-6 text-muted-foreground">
+                  {version.circleOfCompetence || version.minimumMarginOfSafety || "该版本暂未填写核心原则内容。"}
+                </p>
+              </article>
+            ))
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-6">
+        <h2 className="text-xl font-semibold">与上一版变化</h2>
+        {!current ? (
+          <EmptyState text="保存第一版原则后，这里会展示后续版本变化。" />
+        ) : !previous ? (
+          <EmptyState text={`当前只有 v${current.version}，下一次修改后会显示字段变化。`} />
+        ) : changes.length === 0 ? (
+          <EmptyState text={`v${current.version} 与 v${previous.version} 暂无可见字段变化。`} />
+        ) : (
+          <div className="mt-5 space-y-3">
+            <div className="rounded-md border border-border bg-background p-3 text-sm leading-6 text-muted-foreground">
+              当前 v{current.version} 对比上一版 v{previous.version}，共变化 {changes.length} 个字段。
+            </div>
+            {changes.map(({ key, label }) => (
+              <div key={String(key)} className="rounded-lg border border-border bg-background p-4">
+                <div className="text-sm font-semibold text-primary">{label}</div>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <InfoBlock title={`v${previous.version}`} value={String(previous[key] || "未填写")} />
+                  <InfoBlock title={`v${current.version}`} value={String(current[key] || "未填写")} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/lib/investment-system/queries.ts
+++ b/src/lib/investment-system/queries.ts
@@ -20,9 +20,17 @@ export async function getActiveInvestmentPrinciple() {
   return principle;
 }
 
+export async function getInvestmentPrincipleHistory() {
+  return db
+    .select()
+    .from(investmentPrinciples)
+    .orderBy(desc(investmentPrinciples.version), desc(investmentPrinciples.createdAt));
+}
+
 export async function getSystemPageData() {
-  const [principle, companyRows, runRows, decisionRows, templates] = await Promise.all([
+  const [principle, principleHistory, companyRows, runRows, decisionRows, templates] = await Promise.all([
     getActiveInvestmentPrinciple(),
+    getInvestmentPrincipleHistory(),
     db.select().from(companies).orderBy(desc(companies.updatedAt)),
     db
       .select({
@@ -47,6 +55,7 @@ export async function getSystemPageData() {
 
   return {
     principle,
+    principleHistory,
     companies: companyRows,
     recentRuns: runRows,
     recentDecisions: decisionRows,


### PR DESCRIPTION
## 关联 Issue

Closes #43

## 改动摘要

- 保存已有投资原则时不再覆盖原记录，而是生成新版本。
- 旧版本保留为历史版本，当前版本使用 active=true。
- 新建原则时会接续历史最大版本号，避免版本号回退。
- 系统页新增“原则版本历史”面板。
- 系统页新增“与上一版变化”面板，展示当前版本和上一版本的字段差异。
- 决策检查清单继续绑定保存时的当前原则版本 ID，保证历史决策可追溯。

## 主要文件

- app/system/actions.ts
- app/system/page.tsx
- src/lib/investment-system/queries.ts

## 验证

- [x] npm run typecheck
- [x] npm run build
- [x] 验证 /system 返回 200
- [x] 验证页面包含原则版本历史与上一版变化区域
- [x] 验证 CSS 资源返回 200

## 产品边界

本功能只追踪用户自己写下的投资原则变化，不自动替用户制定原则，也不输出买入、卖出、持有建议。

## 数据库迁移

无新增迁移。复用 investment_principles 表中已有 version 与 active 字段。

## 风险

历史版本会增加 investment_principles 记录数量，但不会影响已有决策、检查清单和复盘记录。旧决策仍通过 principleId 指向当时绑定的原则版本。

## 回退方案

如需回退，直接 revert 本 PR；已生成的历史原则记录不会破坏现有业务数据。