### PR TITLE
增强估值敏感性图表与关键变量矩阵

### DIFF
--- a/app/valuations/page.tsx
+++ b/app/valuations/page.tsx
@@ -5,7 +5,11 @@ import { SectionHeader } from "@/components/ui/section-header";
 import { AiValuationDraftPanel } from "@/components/valuations/ai-valuation-draft-panel";
 import { SensitivityChartLazy } from "@/components/valuations/sensitivity-chart-lazy";
 import type { companies, valuations } from "@/db/schema";
-import type { ValuationResult, ValuationScenarioInput } from "@/lib/valuations/calculations";
+import {
+  calculateValuationSensitivity,
+  type ValuationResult,
+  type ValuationScenarioInput
+} from "@/lib/valuations/calculations";
 import {
   getTemplate,
   labelFor,
@@ -291,6 +295,15 @@ function ValuationCard({ valuation, company }: { valuation: Valuation; company: 
   const bull = parseJson<ValuationScenarioInput>(valuation.scenarioBullJson);
   const template = getTemplate(valuation.templateType);
   const currentPrice = valuation.currentPrice / 100;
+  const sharesOutstanding = valuation.sharesOutstanding / 100;
+  const sensitivityMatrix = isScenarioInput(base)
+    ? calculateValuationSensitivity({
+        templateType: template.value,
+        currentPrice,
+        sharesOutstanding,
+        baseScenario: base
+      })
+    : undefined;
   const aiDraft = `请作为耐心的价值投资导师，用通俗语言解释这份 A 股估值。不要给买入或卖出建议，只解释估值方法、关键参数、安全边际和主要风险。公司=${company ? `${company.stockName}（${company.stockCode}）` : "未关联"}；模板=${template.label}；当前价格=${formatNumber(currentPrice)}；估值区间=${formatNumber(result.lowValuePerShare)}-${formatNumber(result.highValuePerShare)}；中性情景=${formatNumber(result.baseValuePerShare)}；安全边际=${formatPercent(result.baseMarginOfSafety)}；悲观假设=${bear.notes || "未填写"}；中性假设=${base.notes || "未填写"}；乐观假设=${bull.notes || "未填写"}。`;
   const opponentDraft = `请作为投资委员会反方委员，质疑这份 A 股估值。不要给买入或卖出建议，请重点找乐观假设、模型误用、风险遗漏和需要补证据的地方。公司=${company ? `${company.stockName}（${company.stockCode}）` : "未关联"}；模板=${template.label}；当前价格=${formatNumber(currentPrice)}；估值区间=${formatNumber(result.lowValuePerShare)}-${formatNumber(result.highValuePerShare)}；中性安全边际=${formatPercent(result.baseMarginOfSafety)}；风险提示=${result.riskFlags.join("；") || "无"}。`;
 
@@ -318,8 +331,11 @@ function ValuationCard({ valuation, company }: { valuation: Valuation; company: 
         currentPrice={currentPrice}
         data={result.scenarioResults.map((scenario) => ({
           name: labelFor(scenarios, scenario.name),
-          valuePerShare: scenario.valuePerShare
+          valuePerShare: scenario.valuePerShare,
+          marginOfSafety: scenario.marginOfSafety,
+          impliedUpside: scenario.impliedUpside
         }))}
+        matrix={sensitivityMatrix}
       />
 
       {result.riskFlags.length > 0 ? (
@@ -470,4 +486,14 @@ function formatPercent(value: number) {
   }
 
   return `${(value * 100).toFixed(1)}%`;
+}
+
+function isScenarioInput(value: Partial<ValuationScenarioInput>): value is ValuationScenarioInput {
+  return (
+    typeof value.basisAmount === "number" &&
+    typeof value.growthRate === "number" &&
+    typeof value.valuationMultiple === "number" &&
+    typeof value.discountRate === "number" &&
+    typeof value.terminalGrowthRate === "number"
+  );
 }

--- a/src/components/valuations/sensitivity-chart-lazy.tsx
+++ b/src/components/valuations/sensitivity-chart-lazy.tsx
@@ -13,10 +13,23 @@ const SensitivityChart = dynamic(() => import("@/components/valuations/sensitivi
 
 export function SensitivityChartLazy({
   data,
-  currentPrice
+  currentPrice,
+  matrix
 }: {
-  data: Array<{ name: string; valuePerShare: number }>;
+  data: Array<{ name: string; valuePerShare: number; marginOfSafety: number; impliedUpside: number }>;
   currentPrice: number;
+  matrix?: {
+    rowAxisLabel: string;
+    columnAxisLabel: string;
+    rows: string[];
+    columns: string[];
+    cells: Array<{
+      rowLabel: string;
+      columnLabel: string;
+      valuePerShare: number;
+      marginOfSafety: number;
+    }>;
+  };
 }) {
-  return <SensitivityChart data={data} currentPrice={currentPrice} />;
+  return <SensitivityChart data={data} currentPrice={currentPrice} matrix={matrix} />;
 }

--- a/src/components/valuations/sensitivity-chart.tsx
+++ b/src/components/valuations/sensitivity-chart.tsx
@@ -4,6 +4,7 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  Cell,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
@@ -14,23 +15,50 @@ import {
 type SensitivityPoint = {
   name: string;
   valuePerShare: number;
+  marginOfSafety: number;
+  impliedUpside: number;
+};
+
+type SensitivityMatrix = {
+  rowAxisLabel: string;
+  columnAxisLabel: string;
+  rows: string[];
+  columns: string[];
+  cells: Array<{
+    rowLabel: string;
+    columnLabel: string;
+    valuePerShare: number;
+    marginOfSafety: number;
+  }>;
 };
 
 export default function SensitivityChart({
   data,
-  currentPrice
+  currentPrice,
+  matrix
 }: {
   data: SensitivityPoint[];
   currentPrice: number;
+  matrix?: SensitivityMatrix;
 }) {
   if (data.length === 0) {
     return null;
   }
 
+  const sortedValues = data.map((item) => item.valuePerShare).sort((a, b) => a - b);
+  const low = sortedValues[0] ?? 0;
+  const high = sortedValues[sortedValues.length - 1] ?? 0;
+  const base = data.find((item) => item.name === "中性") ?? data[1] ?? data[0];
+
   return (
     <div className="mt-4 rounded-md border border-border bg-card p-3">
       <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-        <div className="text-xs font-semibold text-primary">三情景估值图</div>
+        <div>
+          <div className="text-xs font-semibold text-primary">估值敏感性视图</div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            区间 {formatNumber(low)} - {formatNumber(high)} 元/股，中性安全边际 {formatPercent(base.marginOfSafety)}
+          </div>
+        </div>
         <div className="text-xs text-muted-foreground">虚线为当前价格</div>
       </div>
       <div className="mt-3 h-56 w-full">
@@ -74,10 +102,101 @@ export default function SensitivityChart({
                 }}
               />
             ) : null}
-            <Bar dataKey="valuePerShare" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="valuePerShare" radius={[4, 4, 0, 0]}>
+              {data.map((item) => (
+                <Cell key={item.name} fill={colorForMargin(item.marginOfSafety)} />
+              ))}
+            </Bar>
           </BarChart>
         </ResponsiveContainer>
       </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-3">
+        {data.map((item) => (
+          <div key={item.name} className="rounded-md border border-border bg-background p-3">
+            <div className="text-xs font-semibold text-primary">{item.name}情景</div>
+            <div className="mt-2 text-sm font-semibold">{formatNumber(item.valuePerShare)} 元/股</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              安全边际 {formatPercent(item.marginOfSafety)} / 隐含涨跌 {formatPercent(item.impliedUpside)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {matrix && matrix.rows.length > 0 && matrix.columns.length > 0 ? (
+        <div className="mt-4 overflow-x-auto rounded-md border border-border bg-background">
+          <div className="border-b border-border px-3 py-2 text-xs font-semibold text-primary">
+            中性情景关键变量矩阵：{matrix.rowAxisLabel} x {matrix.columnAxisLabel}
+          </div>
+          <table className="w-full min-w-[420px] border-collapse text-sm">
+            <thead>
+              <tr>
+                <th className="border-b border-r border-border px-3 py-2 text-left text-xs text-muted-foreground">
+                  {matrix.rowAxisLabel} \\ {matrix.columnAxisLabel}
+                </th>
+                {matrix.columns.map((column) => (
+                  <th key={column} className="border-b border-border px-3 py-2 text-left text-xs text-muted-foreground">
+                    {column}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {matrix.rows.map((row) => (
+                <tr key={row}>
+                  <th className="border-r border-border px-3 py-2 text-left text-xs font-semibold text-muted-foreground">
+                    {row}
+                  </th>
+                  {matrix.columns.map((column) => {
+                    const cell = matrix.cells.find((item) => item.rowLabel === row && item.columnLabel === column);
+
+                    return (
+                      <td key={`${row}-${column}`} className="px-3 py-2">
+                        <div className="font-semibold">{formatNumber(cell?.valuePerShare ?? 0)}</div>
+                        <div className={toneForMargin(cell?.marginOfSafety ?? 0)}>
+                          {formatPercent(cell?.marginOfSafety ?? 0)}
+                        </div>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
     </div>
   );
+}
+
+function formatNumber(value: number) {
+  return Number.isFinite(value) ? value.toFixed(2) : "0.00";
+}
+
+function formatPercent(value: number) {
+  return Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : "0.0%";
+}
+
+function colorForMargin(value: number) {
+  if (value >= 0.25) {
+    return "hsl(165 55% 34%)";
+  }
+
+  if (value >= 0) {
+    return "hsl(var(--primary))";
+  }
+
+  return "hsl(4 65% 50%)";
+}
+
+function toneForMargin(value: number) {
+  if (value >= 0.25) {
+    return "mt-1 text-xs font-semibold text-emerald-700";
+  }
+
+  if (value >= 0) {
+    return "mt-1 text-xs font-semibold text-primary";
+  }
+
+  return "mt-1 text-xs font-semibold text-red-700";
 }

--- a/src/lib/valuations/calculations.ts
+++ b/src/lib/valuations/calculations.ts
@@ -29,6 +29,21 @@ export type ValuationResult = {
   riskFlags: string[];
 };
 
+export type SensitivityCell = {
+  rowLabel: string;
+  columnLabel: string;
+  valuePerShare: number;
+  marginOfSafety: number;
+};
+
+export type ValuationSensitivityMatrix = {
+  rowAxisLabel: string;
+  columnAxisLabel: string;
+  rows: string[];
+  columns: string[];
+  cells: SensitivityCell[];
+};
+
 export function calculateValuation({
   templateType,
   currentPrice,
@@ -54,6 +69,70 @@ export function calculateValuation({
     baseImpliedUpside: base?.impliedUpside ?? 0,
     scenarioResults,
     riskFlags: buildRiskFlags({ templateType, currentPrice, sharesOutstanding, scenarios, baseValue: base?.valuePerShare ?? 0 })
+  };
+}
+
+export function calculateValuationSensitivity({
+  templateType,
+  currentPrice,
+  sharesOutstanding,
+  baseScenario
+}: {
+  templateType: ValuationTemplateType;
+  currentPrice: number;
+  sharesOutstanding: number;
+  baseScenario: ValuationScenarioInput;
+}): ValuationSensitivityMatrix {
+  const growthSteps = [-0.02, 0, 0.02];
+  const multipleSteps = [-0.15, 0, 0.15];
+  const discountSteps = [-0.01, 0, 0.01];
+  const terminalSteps = [-0.005, 0, 0.005];
+  const isManufacturing = templateType === "manufacturing";
+  const rowAxisLabel = isManufacturing ? "折现率" : "增长率";
+  const columnAxisLabel = isManufacturing ? "永续增长率" : "估值倍数";
+  const rowSteps = isManufacturing ? discountSteps : growthSteps;
+  const columnSteps = isManufacturing ? terminalSteps : multipleSteps;
+  const rows = rowSteps.map((step) =>
+    isManufacturing
+      ? formatPercentLabel(baseScenario.discountRate + step)
+      : formatPercentLabel(baseScenario.growthRate + step)
+  );
+  const columns = columnSteps.map((step) =>
+    isManufacturing
+      ? formatPercentLabel(baseScenario.terminalGrowthRate + step)
+      : formatMultipleLabel(baseScenario.valuationMultiple * (1 + step))
+  );
+
+  const cells = rowSteps.flatMap((rowStep, rowIndex) =>
+    columnSteps.map((columnStep, columnIndex) => {
+      const scenario = {
+        ...baseScenario,
+        growthRate: isManufacturing ? baseScenario.growthRate : Math.max(baseScenario.growthRate + rowStep, -0.95),
+        valuationMultiple: isManufacturing
+          ? baseScenario.valuationMultiple
+          : Math.max(baseScenario.valuationMultiple * (1 + columnStep), 0),
+        discountRate: isManufacturing ? Math.max(baseScenario.discountRate + rowStep, 0.01) : baseScenario.discountRate,
+        terminalGrowthRate: isManufacturing
+          ? Math.max(baseScenario.terminalGrowthRate + columnStep, -0.95)
+          : baseScenario.terminalGrowthRate
+      };
+      const result = calculateScenario({ templateType, currentPrice, sharesOutstanding, scenario });
+
+      return {
+        rowLabel: rows[rowIndex],
+        columnLabel: columns[columnIndex],
+        valuePerShare: result.valuePerShare,
+        marginOfSafety: result.marginOfSafety
+      };
+    })
+  );
+
+  return {
+    rowAxisLabel,
+    columnAxisLabel,
+    rows,
+    columns,
+    cells
   };
 }
 
@@ -174,4 +253,12 @@ function buildRiskFlags({
 
 function round(value: number) {
   return Math.round(value * 10000) / 10000;
+}
+
+function formatPercentLabel(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatMultipleLabel(value: number) {
+  return `${value.toFixed(1)}x`;
 }


### PR DESCRIPTION
## 关联 Issue

Closes #45

## 改动摘要

- 增强估值卡片中的三情景图表。
- 图表显示估值区间、中性安全边际和当前价格参考线。
- 每个情景显示每股估值、安全边际和隐含涨跌幅。
- 新增中性情景关键变量敏感性矩阵。
- 非制造业模板使用增长率 x 估值倍数矩阵。
- 制造业模板使用折现率 x 永续增长率矩阵。
- 不新增数据库字段，基于已保存的情景参数即时计算。

## 主要文件

- app/valuations/page.tsx
- src/components/valuations/sensitivity-chart.tsx
- src/components/valuations/sensitivity-chart-lazy.tsx
- src/lib/valuations/calculations.ts

## 验证

- [x] npm run typecheck
- [x] npm run build
- [x] 验证 /valuations 返回 200
- [x] 验证页面包含估值敏感性视图与关键变量矩阵文案
- [x] 验证 CSS 资源返回 200

## 产品边界

本功能只展示估值假设的敏感性、安全边际和风险，不输出买入、卖出、持有建议，也不生成目标价或交易信号。

## 数据库迁移

无新增迁移。

## 风险

本地当前没有估值记录，因此 HTTP 烟测验证页面可渲染和资源正常；具体图表内容依赖用户已有或后续创建的估值记录。核心计算已通过 TypeScript 与生产构建校验。

## 回退方案

如需回退，直接 revert 本 PR；不会影响已有估值、观察池、决策或复盘数据。