### PR TITLE
增强真实 A 股案例估值评估过程

### DIFF
--- a/src/components/learning/a-share-case-panel.tsx
+++ b/src/components/learning/a-share-case-panel.tsx
@@ -1,5 +1,16 @@
 import Link from "next/link";
-import { Bot, Building2, CheckCircle2, FileSearch, ShieldAlert } from "lucide-react";
+import {
+  Bot,
+  Building2,
+  Calculator,
+  CheckCircle2,
+  FileSearch,
+  GitCompare,
+  LineChart,
+  ListChecks,
+  Scale,
+  ShieldAlert
+} from "lucide-react";
 import type { AShareCaseStudy } from "@/lib/learning/a-share-cases";
 
 type AShareCasePanelProps = {
@@ -7,8 +18,9 @@ type AShareCasePanelProps = {
 };
 
 export function AShareCasePanel({ caseStudy }: AShareCasePanelProps) {
-  const mentorDraft = `请作为耐心的价值投资导师，带我研究这个 A 股案例：${caseStudy.companyName}（${caseStudy.stockCode}）。不要给买入、卖出或持有建议，只帮助我理解业务、关键变量、估值模板、证据清单和风险。案例主题=${caseStudy.caseTheme}；估值模板=${caseStudy.valuationTemplate}；关键问题=${caseStudy.keyQuestions.join("；")}。`;
-  const opponentDraft = `请作为投资委员会反方委员，质疑我研究 ${caseStudy.companyName}（${caseStudy.stockCode}）时可能遗漏的证据和过度乐观假设。不要给买入、卖出或持有建议。业务快照=${caseStudy.businessSnapshot}；关键风险=${caseStudy.riskReminders.join("；")}；证据清单=${caseStudy.evidenceChecklist.join("；")}。`;
+  const walkthrough = caseStudy.valuationWalkthrough;
+  const mentorDraft = `请作为耐心的价值投资导师，带我研究这个 A 股案例：${caseStudy.companyName}（${caseStudy.stockCode}）。不要给买入、卖出或持有建议，只帮助我理解业务、关键变量、估值模板、证据清单和风险。案例主题=${caseStudy.caseTheme}；估值模板=${caseStudy.valuationTemplate}；关键问题=${caseStudy.keyQuestions.join("；")}；${walkthrough ? `估值教学边界=${walkthrough.boundaryNote}；三情景=${walkthrough.scenarios.map((scenario) => `${scenario.name}:${scenario.equityValueRange}`).join("；")}。` : ""}`;
+  const opponentDraft = `请作为投资委员会反方委员，质疑我研究 ${caseStudy.companyName}（${caseStudy.stockCode}）时可能遗漏的证据和过度乐观假设。不要给买入、卖出或持有建议。业务快照=${caseStudy.businessSnapshot}；关键风险=${caseStudy.riskReminders.join("；")}；证据清单=${caseStudy.evidenceChecklist.join("；")}；${walkthrough ? `估值过程=${walkthrough.scenarios.map((scenario) => `${scenario.name}假设:${scenario.assumptions.join("、")}`).join("；")}。` : ""}`;
 
   return (
     <div className="rounded-lg border border-border bg-card p-5">
@@ -40,6 +52,8 @@ export function AShareCasePanel({ caseStudy }: AShareCasePanelProps) {
         <ListBlock title="风险提醒" items={caseStudy.riskReminders} />
       </div>
 
+      {walkthrough ? <ValuationWalkthrough caseStudy={caseStudy} /> : null}
+
       <div className="mt-5 rounded-md border border-border bg-background p-4">
         <div className="flex items-center gap-2 text-sm font-semibold text-primary">
           <FileSearch className="h-4 w-4" aria-hidden />
@@ -69,6 +83,155 @@ export function AShareCasePanel({ caseStudy }: AShareCasePanelProps) {
           <ShieldAlert className="h-4 w-4" aria-hidden />
           让反方委员质疑
         </Link>
+      </div>
+    </div>
+  );
+}
+
+function ValuationWalkthrough({ caseStudy }: { caseStudy: AShareCaseStudy }) {
+  const walkthrough = caseStudy.valuationWalkthrough;
+
+  if (!walkthrough) {
+    return null;
+  }
+
+  return (
+    <section className="mt-6 space-y-5 rounded-lg border border-border bg-background p-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+            <Calculator className="h-4 w-4" aria-hidden />
+            估值评估过程
+          </div>
+          <h3 className="mt-2 text-lg font-semibold">如何用财报推演 {caseStudy.companyName} 的价值范围</h3>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">{walkthrough.boundaryNote}</p>
+        </div>
+        <span className="rounded-md border border-border bg-card px-3 py-2 text-xs font-semibold text-muted-foreground">
+          {walkthrough.dataAsOf}
+        </span>
+      </div>
+
+      <InfoBlock title="数据来源与教学口径" value={walkthrough.sourceNote} />
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        {walkthrough.preferredTools.map((tool) => (
+          <div key={tool.name} className="rounded-md border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+              <Scale className="h-4 w-4" aria-hidden />
+              {tool.name}
+            </div>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{tool.reason}</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{tool.useCase}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-md border border-border bg-card p-4">
+        <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+          <FileSearch className="h-4 w-4" aria-hidden />
+          财报取数路径
+        </div>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          {walkthrough.financialInputs.map((input) => (
+            <div key={input.label} className="rounded-md border border-border bg-background p-3">
+              <div className="text-sm font-semibold">{input.label}</div>
+              <div className="mt-1 text-lg font-semibold text-primary">{input.value}</div>
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">来源：{input.source}</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{input.useInValuation}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <ListBlock title="计算步骤" items={walkthrough.calculationSteps} />
+
+      <div className="rounded-md border border-border bg-card p-4">
+        <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+          <LineChart className="h-4 w-4" aria-hidden />
+          悲观 / 中性 / 乐观三情景
+        </div>
+        <div className="mt-3 grid gap-3 xl:grid-cols-3">
+          {walkthrough.scenarios.map((scenario) => (
+            <div key={scenario.name} className="rounded-md border border-border bg-background p-4">
+              <h4 className="font-semibold">{scenario.name}</h4>
+              <div className="mt-3 space-y-2">
+                {scenario.assumptions.map((assumption) => (
+                  <div key={assumption} className="flex gap-2 text-sm leading-6 text-muted-foreground">
+                    <CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-primary" aria-hidden />
+                    <span>{assumption}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-4 rounded-md border border-border bg-card p-3 text-sm">
+                <div className="font-semibold text-primary">公式</div>
+                <p className="mt-1 leading-6 text-muted-foreground">{scenario.formula}</p>
+              </div>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-1">
+                <MetricBox label="股权价值区间" value={scenario.equityValueRange} />
+                <MetricBox label="每股教学区间" value={scenario.perShareRange} />
+              </div>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">{scenario.interpretation}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <StructuredBlock
+          icon={<GitCompare className="h-4 w-4" aria-hidden />}
+          title="同行比较：优势与需要警惕的地方"
+          items={walkthrough.peerComparison.map(
+            (item) => `${item.dimension}：优势：${item.advantages} 需要警惕：${item.watchouts}`
+          )}
+        />
+        <StructuredBlock
+          icon={<ListChecks className="h-4 w-4" aria-hidden />}
+          title="长期价值研究检查"
+          items={walkthrough.longTermValueChecklist.map(
+            (item) => `${item.question}：${item.whyItMatters}`
+          )}
+        />
+      </div>
+
+      <StructuredBlock
+        icon={<ListChecks className="h-4 w-4" aria-hidden />}
+        title="应用到的价值投资知识点"
+        items={walkthrough.knowledgeLinks.map((item) => `${item.concept}：${item.application}`)}
+      />
+    </section>
+  );
+}
+
+function MetricBox({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="text-xs font-semibold text-muted-foreground">{label}</div>
+      <div className="mt-1 text-sm font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function StructuredBlock({
+  icon,
+  title,
+  items
+}: {
+  icon: React.ReactNode;
+  title: string;
+  items: string[];
+}) {
+  return (
+    <div className="rounded-md border border-border bg-card p-4">
+      <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+        {icon}
+        {title}
+      </div>
+      <div className="mt-3 space-y-2">
+        {items.map((item) => (
+          <div key={item} className="rounded-md border border-border bg-background px-3 py-2 text-sm leading-6 text-muted-foreground">
+            {item}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/lib/learning/a-share-cases.ts
+++ b/src/lib/learning/a-share-cases.ts
@@ -12,6 +12,46 @@ export type AShareCaseStudy = {
   evidenceChecklist: string[];
   riskReminders: string[];
   sourceHints: string[];
+  valuationWalkthrough?: AShareValuationWalkthrough;
+};
+
+export type AShareValuationWalkthrough = {
+  dataAsOf: string;
+  sourceNote: string;
+  boundaryNote: string;
+  preferredTools: Array<{
+    name: string;
+    reason: string;
+    useCase: string;
+  }>;
+  financialInputs: Array<{
+    label: string;
+    value: string;
+    source: string;
+    useInValuation: string;
+  }>;
+  calculationSteps: string[];
+  scenarios: Array<{
+    name: string;
+    assumptions: string[];
+    formula: string;
+    equityValueRange: string;
+    perShareRange: string;
+    interpretation: string;
+  }>;
+  peerComparison: Array<{
+    dimension: string;
+    advantages: string;
+    watchouts: string;
+  }>;
+  longTermValueChecklist: Array<{
+    question: string;
+    whyItMatters: string;
+  }>;
+  knowledgeLinks: Array<{
+    concept: string;
+    application: string;
+  }>;
 };
 
 const aShareCaseStudies: AShareCaseStudy[] = [
@@ -43,7 +83,202 @@ const aShareCaseStudies: AShareCaseStudy[] = [
       "B 端业务可能带来更强周期性和更复杂的竞争格局。",
       "原材料、汇率和海外贸易环境会影响利润率。"
     ],
-    sourceHints: ["公司年度报告", "深交所定期报告披露", "公司官网投资者关系资料"]
+    sourceHints: ["巨潮资讯网 2025 年年度报告", "深交所定期报告披露", "公司官网投资者关系资料"],
+    valuationWalkthrough: {
+      dataAsOf: "2025 年年度报告，财务报表批准报出日为 2026-03-30",
+      sourceNote:
+        "示例数据来自美的集团 2025 年年度报告：营业收入 4564.52 亿元，归母净利润 439.45 亿元，经营活动现金流量净额 533.46 亿元，购建固定资产、无形资产和其他长期资产支付现金 111.42 亿元，期末总股本 75.971 亿股。",
+      boundaryNote:
+        "以下只是价值投资学习中的估值演算样例，不是实时估值，不构成买入、卖出或持有建议。用户应自行更新最新年报、季报、股本和市场价格后再判断。",
+      preferredTools: [
+        {
+          name: "制造业所有者收益 / 自由现金流估值",
+          reason:
+            "美的属于成熟消费制造和多元制造平台，经营现金流、资本开支、分红和回购是判断股东回报的核心。",
+          useCase:
+            "先用经营现金流减维护性资本开支估算所有者收益，再给出悲观、中性、乐观倍数区间。"
+        },
+        {
+          name: "消费股 PE 情景估值",
+          reason:
+            "智能家居主业具有消费属性，归母净利润和估值倍数可作为交叉验证，但不能单独替代现金流分析。",
+          useCase:
+            "用归母净利润乘以保守、中性、乐观 PE 区间，检查自由现金流估值是否过度乐观。"
+        },
+        {
+          name: "反向 DCF",
+          reason:
+            "当市场价格较高时，反向 DCF 能倒推出市场隐含的长期增长和利润率要求。",
+          useCase:
+            "把当前市值倒推成未来 5-10 年自由现金流增长要求，再判断这些要求是否被业务证据支持。"
+        }
+      ],
+      financialInputs: [
+        {
+          label: "营业收入",
+          value: "4564.52 亿元",
+          source: "2025 年报主要会计数据和利润表",
+          useInValuation: "用于判断公司规模、增长基础和分业务收入拆分是否支撑估值假设。"
+        },
+        {
+          label: "归母净利润",
+          value: "439.45 亿元",
+          source: "2025 年报主要会计数据",
+          useInValuation: "用于 PE 情景估值和利润质量交叉验证。"
+        },
+        {
+          label: "经营活动现金流量净额",
+          value: "533.46 亿元",
+          source: "2025 年报现金流量表",
+          useInValuation: "用于判断利润是否转化为现金，是所有者收益估值的起点。"
+        },
+        {
+          label: "购建固定资产、无形资产和其他长期资产支付现金",
+          value: "111.42 亿元",
+          source: "2025 年报现金流量表",
+          useInValuation: "作为资本开支近似值；教学估算中用经营现金流减该项得到自由现金流。"
+        },
+        {
+          label: "教学口径自由现金流",
+          value: "约 422.04 亿元",
+          source: "533.46 亿元经营现金流 - 111.42 亿元资本开支",
+          useInValuation: "作为三情景估值的基础自由现金流；实际研究还需区分维护性和扩张性资本开支。"
+        },
+        {
+          label: "期末总股本",
+          value: "约 75.971 亿股",
+          source: "2025 年报财务报表附注股本",
+          useInValuation: "用于把股权价值区间换算为每股价值区间。"
+        },
+        {
+          label: "2025 年度现金分红方案",
+          value: "每 10 股派发现金 43 元，含中期分红",
+          source: "2025 年报利润分配方案",
+          useInValuation: "用于检查股东回报、现金流覆盖和资本配置纪律。"
+        }
+      ],
+      calculationSteps: [
+        "第一步：确认公司类型。美的不是纯消费股，也不是强周期股，第一工具选制造业所有者收益 / 自由现金流估值。",
+        "第二步：从年报现金流量表取经营现金流 533.46 亿元，再减购建固定资产等长期资产现金流出 111.42 亿元，得到教学口径自由现金流约 422.04 亿元。",
+        "第三步：判断这 422.04 亿元是否是常态。需要检查过去 3-5 年经营现金流、资本开支、存货、应收和海外收入，而不是只用单年数字。",
+        "第四步：设置三情景。悲观情景降低自由现金流并降低倍数；中性情景使用接近当前现金流的区间；乐观情景要求海外、B 端业务和效率提升能支撑更高现金流和倍数。",
+        "第五步：用股权价值 = 常态自由现金流 x 合理倍数，得到总市值区间；再除以总股本约 75.971 亿股，得到每股教学价值区间。",
+        "第六步：用 PE 情景估值交叉验证。归母净利润 439.45 亿元 x 12-18 倍，对比自由现金流法是否明显偏离。",
+        "第七步：把估值结果和当前市场价格比较时，只能形成安全边际检查，不自动生成买入、卖出或持有建议。"
+      ],
+      scenarios: [
+        {
+          name: "悲观情景",
+          assumptions: [
+            "国内家电需求成熟，收入增速放缓。",
+            "海外、B 端业务带来增长，但毛利率和资本开支压力抵消一部分收益。",
+            "常态自由现金流按 380-410 亿元估算，合理倍数按 10-12 倍。"
+          ],
+          formula: "380-410 亿元自由现金流 x 10-12 倍",
+          equityValueRange: "约 3800-4920 亿元",
+          perShareRange: "约 50-65 元 / 股",
+          interpretation:
+            "用于压力测试：如果成熟制造估值中枢下移，当前判断是否仍有足够保护。"
+        },
+        {
+          name: "中性情景",
+          assumptions: [
+            "智能家居主业保持稳定，海外业务和商业及工业解决方案继续贡献温和增长。",
+            "经营现金流质量维持，资本开支处于可控区间。",
+            "常态自由现金流按 420-470 亿元估算，合理倍数按 13-15 倍。"
+          ],
+          formula: "420-470 亿元自由现金流 x 13-15 倍",
+          equityValueRange: "约 5460-7050 亿元",
+          perShareRange: "约 72-93 元 / 股",
+          interpretation:
+            "用于基准判断：公司维持成熟龙头现金流质量，但不假设估值显著扩张。"
+        },
+        {
+          name: "乐观情景",
+          assumptions: [
+            "海外收入、B 端业务和工业技术等第二曲线持续兑现。",
+            "规模效率、品牌渠道和资本配置共同提升自由现金流。",
+            "常态自由现金流按 480-540 亿元估算，合理倍数按 16-18 倍。"
+          ],
+          formula: "480-540 亿元自由现金流 x 16-18 倍",
+          equityValueRange: "约 7680-9720 亿元",
+          perShareRange: "约 101-128 元 / 股",
+          interpretation:
+            "用于检验乐观叙事：必须有海外增长、B 端盈利质量和现金流持续改善的证据支持。"
+        }
+      ],
+      peerComparison: [
+        {
+          dimension: "与格力电器比较",
+          advantages:
+            "美的业务更分散，智能家居、商业及工业解决方案、海外收入共同构成多引擎；现金流、分红和回购也适合观察股东回报。",
+          watchouts:
+            "业务更复杂，ToB 和海外业务会引入更多周期、汇率、整合和资本开支变量，不能只按传统白电估值。"
+        },
+        {
+          dimension: "与海尔智家比较",
+          advantages:
+            "美的在制造效率、品类覆盖和 B 端延展上有平台化特征，适合研究成熟制造企业第二增长曲线。",
+          watchouts:
+            "海尔智家全球品牌和海外本土化也有独特优势；比较时要看海外毛利率、费用率、现金流和组织效率，而不是只看收入规模。"
+        },
+        {
+          dimension: "与小熊电器、石头科技等细分消费制造比较",
+          advantages:
+            "美的规模、渠道、供应链、品类和现金流稳定性更强，更适合成熟龙头估值。",
+          watchouts:
+            "大型平台的增速通常低于优秀细分成长公司，估值倍数不能简单套用高成长小家电或科技消费品。"
+        }
+      ],
+      longTermValueChecklist: [
+        {
+          question: "长期是否仍能创造高质量自由现金流？",
+          whyItMatters: "成熟制造龙头的长期价值最终要靠经营现金流、资本开支纪律、分红和回购共同验证。"
+        },
+        {
+          question: "海外和 B 端第二曲线是否提高回报率，而不是稀释现金流？",
+          whyItMatters: "第二增长曲线如果只带来收入，不带来可持续利润和现金流，估值应更保守。"
+        },
+        {
+          question: "护城河是否仍在变宽？",
+          whyItMatters: "品牌、渠道、供应链和规模效率需要持续用份额、毛利率、费用率和库存验证。"
+        },
+        {
+          question: "资本配置是否持续对股东友好？",
+          whyItMatters: "分红、回购、并购、研发和扩产共同决定长期复利质量。"
+        },
+        {
+          question: "价格是否给了足够安全边际？",
+          whyItMatters: "好公司也可能因为买入价格过高而带来普通回报，估值必须和价格比较。"
+        }
+      ],
+      knowledgeLinks: [
+        {
+          concept: "股票背后是企业",
+          application: "先理解智能家居、商业及工业解决方案、海外业务分别如何赚钱。"
+        },
+        {
+          concept: "所有者收益 / 自由现金流",
+          application: "用经营现金流减资本开支，估算可归属股东的现金创造能力。"
+        },
+        {
+          concept: "护城河",
+          application: "用品牌、渠道、规模效率、供应链和海外本土化验证竞争优势。"
+        },
+        {
+          concept: "好公司与好价格",
+          application: "即使公司质量较高，也必须比较当前价格和保守价值区间。"
+        },
+        {
+          concept: "安全边际",
+          application: "通过悲观情景、倍数压缩和现金流下修测试错误容忍度。"
+        },
+        {
+          concept: "反方验证",
+          application: "主动检查地产链、汇率、原材料、海外贸易、B 端周期和资本开支风险。"
+        }
+      ]
+    }
   },
   {
     nodeId: "case-moutai-600519",


### PR DESCRIPTION
## 关联 Issue

Closes #53

## 改动摘要

- 为真实 A 股案例数据增加 `valuationWalkthrough` 结构。
- 以美的集团为第一版样板，新增完整估值教学过程。
- 案例详情页新增“估值评估过程”面板，覆盖：
  - 推荐估值工具
  - 财报取数路径
  - 自由现金流计算步骤
  - 悲观 / 中性 / 乐观三情景区间
  - 同行比较优势与风险
  - 长期价值研究检查
  - 价值投资知识点映射
- AI 导师和反方委员入口补充估值过程上下文。
- 继续明确教育用途，不输出买入、卖出、持有建议。

## 美的集团示例数据来源

- 美的集团 2025 年年度报告，巨潮资讯网披露。
- 示例采用年报中的营业收入、归母净利润、经营活动现金流量净额、购建固定资产等长期资产支付现金、期末股本和分红方案。

## 验证

- [x] npm run typecheck
- [x] npm run build
- [x] /learn/case-midea-000333 返回 200
- [x] 页面包含“估值评估过程”
- [x] 页面包含悲观 / 中性 / 乐观三情景
- [x] 页面包含同行比较、长期价值研究检查、价值投资知识点
- [x] CSS 资源返回 200

## 产品边界

估值区间为学习用教学演算，不是实时估值，不构成任何具体证券的买入、卖出或持有建议。用户需要自行更新最新财报、股本和市场价格，并由用户完成最终判断。

## 数据库迁移

无。

## 回退方案

如需回退，直接 revert 本 PR；不影响用户本地观察池、估值、决策或复盘数据。
